### PR TITLE
feat: add CLI profile system for binary-name-driven branding

### DIFF
--- a/src/main/java/org/lucee/lucli/LuCLI.java
+++ b/src/main/java/org/lucee/lucli/LuCLI.java
@@ -199,6 +199,15 @@ public class LuCLI implements Callable<Integer> {
     public static CliProfile getActiveProfile() {
         return activeProfile;
     }
+
+    /**
+     * Override the active profile. Intended for tests that need to verify
+     * profile-dependent behaviour; production code sets the profile once in
+     * {@link #main(String[])}.
+     */
+    public static void setActiveProfile(CliProfile profile) {
+        activeProfile = profile;
+    }
     
     /**
      * Commands that are treated as internal file-system style commands, routed
@@ -500,8 +509,10 @@ public class LuCLI implements Callable<Integer> {
         // Resolve the CLI profile (branding, home dir) from the binary name.
         // Must happen after prependBinaryNameIfAliased() which normalises the
         // system property, and before executeInProcess() which may read paths.
-        String binaryName = System.getProperty("lucli.binary.name", "lucli");
-        activeProfile = CliProfile.forBinaryName(binaryName);
+        // forBinaryName() normalises paths and extensions internally.
+        activeProfile = CliProfile.forBinaryName(
+            System.getProperty("lucli.binary.name", "lucli")
+        );
 
         int exitCode = executeInProcess(args);
         System.exit(exitCode);
@@ -571,15 +582,13 @@ public class LuCLI implements Callable<Integer> {
      * Only activates when the name is not "lucli" itself.
      */
     private static String[] prependBinaryNameIfAliased(String[] args) {
-        String binaryName = System.getProperty("lucli.binary.name", "lucli");
-
-        // Strip path separators in case the property contains a path fragment
-        if (binaryName.contains("/") || binaryName.contains("\\")) {
-            binaryName = Paths.get(binaryName).getFileName().toString();
-        }
+        String binaryName = CliProfile.normalizeBinaryName(
+            System.getProperty("lucli.binary.name", "lucli")
+        );
 
         // Only activate for non-lucli binary names
-        if ("lucli".equals(binaryName) || "lucli.sh".equals(binaryName) || binaryName.isEmpty()) {
+        if (binaryName == null || binaryName.isEmpty()
+                || "lucli".equalsIgnoreCase(binaryName)) {
             return args;
         }
 

--- a/src/main/java/org/lucee/lucli/LuCLI.java
+++ b/src/main/java/org/lucee/lucli/LuCLI.java
@@ -18,6 +18,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.lucee.lucli.cli.LuCLIVersionProvider;
+import org.lucee.lucli.profile.CliProfile;
+import org.lucee.lucli.profile.DefaultProfile;
 import org.lucee.lucli.cli.commands.CfmlCommand;
 import org.lucee.lucli.cli.commands.CompletionCommand;
 import org.lucee.lucli.cli.commands.DaemonCommand;
@@ -186,8 +188,17 @@ public class LuCLI implements Callable<Integer> {
     public static String envFilePath = null;
     private static boolean lucliScript = false;
     private static volatile Path runtimeCwd = null;
-    
+    private static CliProfile activeProfile = new DefaultProfile();
+
     public static Map<String, String> scriptEnvironment = new HashMap<>(System.getenv());
+
+    /**
+     * The active CLI profile, determined by the binary name at startup.
+     * Controls branding, home directory name, and prompt prefix.
+     */
+    public static CliProfile getActiveProfile() {
+        return activeProfile;
+    }
     
     /**
      * Commands that are treated as internal file-system style commands, routed
@@ -485,6 +496,12 @@ public class LuCLI implements Callable<Integer> {
         // property persists for the JVM's lifetime. Prepending here ensures it
         // happens exactly once.
         args = prependBinaryNameIfAliased(args);
+
+        // Resolve the CLI profile (branding, home dir) from the binary name.
+        // Must happen after prependBinaryNameIfAliased() which normalises the
+        // system property, and before executeInProcess() which may read paths.
+        String binaryName = System.getProperty("lucli.binary.name", "lucli");
+        activeProfile = CliProfile.forBinaryName(binaryName);
 
         int exitCode = executeInProcess(args);
         System.exit(exitCode);
@@ -976,16 +993,11 @@ public class LuCLI implements Callable<Integer> {
         // first few lines can still parse the version without needing to
         // strip the ASCII art banner.
         String ver = getVersion();
-        info.append("LuCLI Version: ").append(ver).append("\n");
-        // info.append("Version: ").append(ver).append("\n");
-        
-        // ASCII art banner
+        info.append(activeProfile.displayName()).append(" Version: ").append(ver).append("\n");
+
+        // ASCII art banner — provided by the active profile
         info.append("\n");
-        info.append(" _           ____ _     ___ \n");
-        info.append("| |   _   _ / ___| |   |_ _|\n");
-        info.append("| |  | | | | |   | |    | | \n");
-        info.append("| |__| |_| | |___| |___ | | \n");
-        info.append("|_____\\__,_|\\____|_____|___|\n");
+        info.append(activeProfile.bannerText());
         info.append("\n");
         
         if (includeLucee) {

--- a/src/main/java/org/lucee/lucli/cli/commands/ReplCommand.java
+++ b/src/main/java/org/lucee/lucli/cli/commands/ReplCommand.java
@@ -79,7 +79,8 @@ public class ReplCommand implements Callable<Integer> {
             // Main REPL loop
             while (true) {
                 try {
-                    String line = reader.readLine("cfml> ");
+                    String prompt = LuCLI.getActiveProfile().promptPrefix() + "> ";
+                    String line = reader.readLine(prompt);
                     
                     if (line == null) {
                         break; // EOF

--- a/src/main/java/org/lucee/lucli/cli/commands/ReplCommand.java
+++ b/src/main/java/org/lucee/lucli/cli/commands/ReplCommand.java
@@ -54,9 +54,9 @@ public class ReplCommand implements Callable<Integer> {
                 .name("CFML REPL")
                 .build();
             
-            // Set up history file for REPL
+            // Set up history file using profile-aware home directory
             Path homeDir = Paths.get(System.getProperty("user.home"));
-            Path historyFile = homeDir.resolve(".lucli").resolve("repl_history");
+            Path historyFile = homeDir.resolve(LuCLI.getActiveProfile().homeDirName()).resolve("repl_history");
             
             LineReader reader = LineReaderBuilder.builder()
                 .terminal(terminal)
@@ -66,7 +66,7 @@ public class ReplCommand implements Callable<Integer> {
                 .build();
             
             // Print welcome banner
-            terminal.writer().println(WindowsSupport.Symbols.ROCKET() + " CFML REPL - LuCLI " + LuCLI.getVersion());
+            terminal.writer().println(WindowsSupport.Symbols.ROCKET() + " CFML REPL - " + LuCLI.getActiveProfile().displayName() + " " + LuCLI.getVersion());
             terminal.writer().println(WindowsSupport.Symbols.INFO() + " Type CFML expressions to evaluate. Type 'exit' or Ctrl+D to quit.");
             terminal.writer().println();
             terminal.writer().flush();

--- a/src/main/java/org/lucee/lucli/paths/LucliPaths.java
+++ b/src/main/java/org/lucee/lucli/paths/LucliPaths.java
@@ -82,9 +82,9 @@ public final class LucliPaths {
             Path normalizedHome = resolvedHome.toAbsolutePath().normalize();
             Path homeParent = normalizedHome.getParent();
             if (homeParent == null) {
-                resolvedBackups = normalizedHome.resolveSibling(".lucli_backups");
+                resolvedBackups = normalizedHome.resolveSibling(LuCLI.getActiveProfile().backupsDirName());
             } else {
-                resolvedBackups = homeParent.resolve(".lucli_backups");
+                resolvedBackups = homeParent.resolve(LuCLI.getActiveProfile().backupsDirName());
             }
         }
 
@@ -98,8 +98,8 @@ public final class LucliPaths {
         Path normalizedHome = lucliHome.toAbsolutePath().normalize();
         Path parent = normalizedHome.getParent();
         Path defaultBackups = parent == null
-            ? normalizedHome.resolveSibling(".lucli_backups")
-            : parent.resolve(".lucli_backups");
+            ? normalizedHome.resolveSibling(LuCLI.getActiveProfile().backupsDirName())
+            : parent.resolve(LuCLI.getActiveProfile().backupsDirName());
         return forHome(normalizedHome, source, defaultBackups);
     }
 

--- a/src/main/java/org/lucee/lucli/paths/LucliPaths.java
+++ b/src/main/java/org/lucee/lucli/paths/LucliPaths.java
@@ -5,6 +5,8 @@ import java.nio.file.Paths;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.lucee.lucli.LuCLI;
+
 /**
  * Centralized LuCLI path resolution.
  *
@@ -66,7 +68,8 @@ public final class LucliPaths {
             if (resolvedUserHome == null || resolvedUserHome.trim().isEmpty()) {
                 resolvedUserHome = System.getProperty("user.home");
             }
-            resolvedHome = Paths.get(resolvedUserHome, ".lucli");
+            String homeDirName = LuCLI.getActiveProfile().homeDirName();
+            resolvedHome = Paths.get(resolvedUserHome, homeDirName);
             source = "default";
         }
 

--- a/src/main/java/org/lucee/lucli/profile/CliProfile.java
+++ b/src/main/java/org/lucee/lucli/profile/CliProfile.java
@@ -1,0 +1,41 @@
+package org.lucee.lucli.profile;
+
+/**
+ * Defines branding and directory conventions for a CLI binary identity.
+ *
+ * <p>LuCLI can be invoked under different binary names (e.g. {@code lucli},
+ * {@code wheels}) via symlinks or the {@code -Dlucli.binary.name} system
+ * property. Each binary name maps to a profile that controls the home
+ * directory name, ASCII art banner, and interactive prompt prefix.</p>
+ */
+public interface CliProfile {
+
+    /** Short identifier for this profile, e.g. {@code "lucli"} or {@code "wheels"}. */
+    String name();
+
+    /** Directory name under the user's home for caches/config, e.g. {@code ".lucli"}. */
+    String homeDirName();
+
+    /** ASCII art banner displayed in {@code --version} output. */
+    String bannerText();
+
+    /** Prefix shown in interactive prompts, e.g. {@code "cfml"} or {@code "wheels"}. */
+    String promptPrefix();
+
+    /** Human-readable display name for version output, e.g. {@code "LuCLI"} or {@code "Wheels"}. */
+    String displayName();
+
+    /**
+     * Resolve the appropriate profile for the given binary name.
+     *
+     * @param binaryName the name the CLI was invoked as (may be {@code null})
+     * @return a {@link WheelsProfile} when the binary name is {@code "wheels"}
+     *         (case-insensitive), otherwise a {@link DefaultProfile}
+     */
+    static CliProfile forBinaryName(String binaryName) {
+        if (binaryName != null && binaryName.equalsIgnoreCase("wheels")) {
+            return new WheelsProfile();
+        }
+        return new DefaultProfile();
+    }
+}

--- a/src/main/java/org/lucee/lucli/profile/CliProfile.java
+++ b/src/main/java/org/lucee/lucli/profile/CliProfile.java
@@ -26,16 +26,57 @@ public interface CliProfile {
     String displayName();
 
     /**
+     * Directory name for backups, placed alongside the home directory.
+     * Defaults to {@code homeDirName() + "_backups"} (e.g. {@code ".lucli_backups"}).
+     */
+    default String backupsDirName() {
+        return homeDirName() + "_backups";
+    }
+
+    /**
      * Resolve the appropriate profile for the given binary name.
      *
+     * <p>The binary name is normalised before matching: path separators are
+     * stripped (keeping only the filename) and common wrapper extensions
+     * ({@code .sh}, {@code .bat}, {@code .cmd}, {@code .exe}) are removed.
+     * This ensures that values like {@code /usr/local/bin/wheels} or
+     * {@code wheels.sh} resolve correctly.</p>
+     *
      * @param binaryName the name the CLI was invoked as (may be {@code null})
-     * @return a {@link WheelsProfile} when the binary name is {@code "wheels"}
-     *         (case-insensitive), otherwise a {@link DefaultProfile}
+     * @return a {@link WheelsProfile} when the normalised binary name is
+     *         {@code "wheels"} (case-insensitive), otherwise a {@link DefaultProfile}
      */
     static CliProfile forBinaryName(String binaryName) {
-        if (binaryName != null && binaryName.equalsIgnoreCase("wheels")) {
+        String normalised = normalizeBinaryName(binaryName);
+        if (normalised != null && normalised.equalsIgnoreCase("wheels")) {
             return new WheelsProfile();
         }
         return new DefaultProfile();
+    }
+
+    /**
+     * Strip path components and common wrapper extensions from a binary name.
+     *
+     * @param binaryName raw binary name (may contain path or extensions)
+     * @return the bare binary name, or {@code null} if input was {@code null}
+     */
+    static String normalizeBinaryName(String binaryName) {
+        if (binaryName == null) {
+            return null;
+        }
+        String name = binaryName.trim();
+        // Strip path — keep only the filename component
+        int lastSlash = Math.max(name.lastIndexOf('/'), name.lastIndexOf('\\'));
+        if (lastSlash >= 0 && lastSlash < name.length() - 1) {
+            name = name.substring(lastSlash + 1);
+        }
+        // Strip common wrapper extensions
+        for (String ext : new String[]{".sh", ".bat", ".cmd", ".exe"}) {
+            if (name.toLowerCase().endsWith(ext)) {
+                name = name.substring(0, name.length() - ext.length());
+                break;
+            }
+        }
+        return name;
     }
 }

--- a/src/main/java/org/lucee/lucli/profile/DefaultProfile.java
+++ b/src/main/java/org/lucee/lucli/profile/DefaultProfile.java
@@ -1,0 +1,37 @@
+package org.lucee.lucli.profile;
+
+/**
+ * Default LuCLI profile — used when invoked as {@code lucli} or any
+ * unrecognised binary name.
+ */
+public class DefaultProfile implements CliProfile {
+
+    @Override
+    public String name() {
+        return "lucli";
+    }
+
+    @Override
+    public String homeDirName() {
+        return ".lucli";
+    }
+
+    @Override
+    public String promptPrefix() {
+        return "cfml";
+    }
+
+    @Override
+    public String displayName() {
+        return "LuCLI";
+    }
+
+    @Override
+    public String bannerText() {
+        return " _           ____ _     ___ \n"
+             + "| |   _   _ / ___| |   |_ _|\n"
+             + "| |  | | | | |   | |    | | \n"
+             + "| |__| |_| | |___| |___ | | \n"
+             + "|_____\\__,_|\\____|_____|___|\n";
+    }
+}

--- a/src/main/java/org/lucee/lucli/profile/WheelsProfile.java
+++ b/src/main/java/org/lucee/lucli/profile/WheelsProfile.java
@@ -1,0 +1,37 @@
+package org.lucee.lucli.profile;
+
+/**
+ * Wheels profile — activated when the CLI is invoked as {@code wheels}.
+ * Uses Wheels-specific branding and a {@code ~/.wheels} home directory.
+ */
+public class WheelsProfile implements CliProfile {
+
+    @Override
+    public String name() {
+        return "wheels";
+    }
+
+    @Override
+    public String homeDirName() {
+        return ".wheels";
+    }
+
+    @Override
+    public String promptPrefix() {
+        return "wheels";
+    }
+
+    @Override
+    public String displayName() {
+        return "Wheels";
+    }
+
+    @Override
+    public String bannerText() {
+        return " __        ___               _     \n"
+             + " \\ \\      / / |__   ___  ___| |___ \n"
+             + "  \\ \\ /\\ / /| '_ \\ / _ \\/ _ \\ / __|\n"
+             + "   \\ V  V / | | | |  __/  __/ \\__ \\\n"
+             + "    \\_/\\_/  |_| |_|\\___|\\___|_|___/\n";
+    }
+}

--- a/src/test/java/org/lucee/lucli/paths/LucliPathsTest.java
+++ b/src/test/java/org/lucee/lucli/paths/LucliPathsTest.java
@@ -4,10 +4,29 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.nio.file.Path;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.lucee.lucli.LuCLI;
+import org.lucee.lucli.profile.CliProfile;
+import org.lucee.lucli.profile.DefaultProfile;
+import org.lucee.lucli.profile.WheelsProfile;
 
 class LucliPathsTest {
+
+    private CliProfile savedProfile;
+
+    @BeforeEach
+    void saveProfile() {
+        savedProfile = LuCLI.getActiveProfile();
+        // Reset to default so tests have a known starting point
+        LuCLI.setActiveProfile(new DefaultProfile());
+    }
+
+    @AfterEach
+    void restoreProfile() {
+        LuCLI.setActiveProfile(savedProfile);
+    }
 
     @Test
     void resolvePrefersSystemPropertyOverEnvironment() {
@@ -37,11 +56,6 @@ class LucliPathsTest {
 
     @Test
     void resolveFallsBackToUserHomeDefault() {
-        // This test depends on the static activeProfile being DefaultProfile
-        // (homeDirName() returns ".lucli"). If another test changes the
-        // active profile without restoring it, this assertion will break.
-        assertEquals(".lucli", LuCLI.getActiveProfile().homeDirName());
-
         LucliPaths.ResolvedPaths paths = LucliPaths.resolve(
             null,
             null,
@@ -54,6 +68,21 @@ class LucliPathsTest {
     }
 
     @Test
+    void resolveFallsBackToWheelsHomeWhenProfileIsWheels() {
+        LuCLI.setActiveProfile(new WheelsProfile());
+
+        LucliPaths.ResolvedPaths paths = LucliPaths.resolve(
+            null,
+            null,
+            "/tmp/home"
+        );
+
+        assertEquals(Path.of("/tmp/home/.wheels").toAbsolutePath().normalize(), paths.home());
+        assertEquals("default", paths.homeSource());
+        assertEquals(Path.of("/tmp/home/.wheels_backups").toAbsolutePath().normalize(), paths.backupsDir());
+    }
+
+    @Test
     void derivedPathsAreBuiltFromHome() {
         LucliPaths.ResolvedPaths paths = LucliPaths.forHome(Path.of("/tmp/lucli"), "test");
 
@@ -62,9 +91,24 @@ class LucliPathsTest {
         assertEquals(Path.of("/tmp/lucli/express").toAbsolutePath().normalize(), paths.expressDir());
         assertEquals(Path.of("/tmp/lucli/deps/git-cache").toAbsolutePath().normalize(), paths.depsGitCacheDir());
         assertEquals(Path.of("/tmp/lucli/modules").toAbsolutePath().normalize(), paths.modulesDir());
-        assertEquals(Path.of("/tmp/.lucli_backups").toAbsolutePath().normalize(), paths.backupsDir());
         assertEquals(Path.of("/tmp/lucli/secrets/local.json").toAbsolutePath().normalize(), paths.secretsStoreFile());
         assertEquals(Path.of("/tmp/lucli/settings.json").toAbsolutePath().normalize(), paths.settingsFile());
+    }
+
+    @Test
+    void forHomeBackupsDirFollowsActiveProfile() {
+        LuCLI.setActiveProfile(new WheelsProfile());
+
+        LucliPaths.ResolvedPaths paths = LucliPaths.forHome(Path.of("/tmp/wheels"), "test");
+
+        assertEquals(Path.of("/tmp/.wheels_backups").toAbsolutePath().normalize(), paths.backupsDir());
+    }
+
+    @Test
+    void forHomeBackupsDirDefaultsToLucliProfile() {
+        LucliPaths.ResolvedPaths paths = LucliPaths.forHome(Path.of("/tmp/lucli"), "test");
+
+        assertEquals(Path.of("/tmp/.lucli_backups").toAbsolutePath().normalize(), paths.backupsDir());
     }
 
     @Test

--- a/src/test/java/org/lucee/lucli/paths/LucliPathsTest.java
+++ b/src/test/java/org/lucee/lucli/paths/LucliPathsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.Test;
+import org.lucee.lucli.LuCLI;
 
 class LucliPathsTest {
 
@@ -36,6 +37,11 @@ class LucliPathsTest {
 
     @Test
     void resolveFallsBackToUserHomeDefault() {
+        // This test depends on the static activeProfile being DefaultProfile
+        // (homeDirName() returns ".lucli"). If another test changes the
+        // active profile without restoring it, this assertion will break.
+        assertEquals(".lucli", LuCLI.getActiveProfile().homeDirName());
+
         LucliPaths.ResolvedPaths paths = LucliPaths.resolve(
             null,
             null,

--- a/src/test/java/org/lucee/lucli/profile/CliProfileTest.java
+++ b/src/test/java/org/lucee/lucli/profile/CliProfileTest.java
@@ -48,6 +48,36 @@ class CliProfileTest {
     }
 
     @Test
+    void forBinaryName_stripsPathFromBinaryName() {
+        CliProfile profile = CliProfile.forBinaryName("/usr/local/bin/wheels");
+        assertInstanceOf(WheelsProfile.class, profile);
+    }
+
+    @Test
+    void forBinaryName_stripsShExtension() {
+        CliProfile profile = CliProfile.forBinaryName("wheels.sh");
+        assertInstanceOf(WheelsProfile.class, profile);
+    }
+
+    @Test
+    void forBinaryName_stripsBatExtension() {
+        CliProfile profile = CliProfile.forBinaryName("wheels.bat");
+        assertInstanceOf(WheelsProfile.class, profile);
+    }
+
+    @Test
+    void forBinaryName_stripsPathAndExtension() {
+        CliProfile profile = CliProfile.forBinaryName("/opt/lucli/bin/wheels.sh");
+        assertInstanceOf(WheelsProfile.class, profile);
+    }
+
+    @Test
+    void forBinaryName_lucliShReturnsDefault() {
+        CliProfile profile = CliProfile.forBinaryName("lucli.sh");
+        assertInstanceOf(DefaultProfile.class, profile);
+    }
+
+    @Test
     void defaultProfile_bannerContainsLuCLI() {
         DefaultProfile profile = new DefaultProfile();
         // The banner should contain recognizable LuCLI ASCII art

--- a/src/test/java/org/lucee/lucli/profile/CliProfileTest.java
+++ b/src/test/java/org/lucee/lucli/profile/CliProfileTest.java
@@ -1,0 +1,63 @@
+package org.lucee.lucli.profile;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CliProfileTest {
+
+    @Test
+    void forBinaryName_returnsWheelsProfileForWheels() {
+        CliProfile profile = CliProfile.forBinaryName("wheels");
+        assertInstanceOf(WheelsProfile.class, profile);
+        assertEquals("wheels", profile.name());
+        assertEquals(".wheels", profile.homeDirName());
+        assertEquals("wheels", profile.promptPrefix());
+        assertEquals("Wheels", profile.displayName());
+    }
+
+    @Test
+    void forBinaryName_returnsWheelsProfileCaseInsensitive() {
+        CliProfile profile = CliProfile.forBinaryName("Wheels");
+        assertInstanceOf(WheelsProfile.class, profile);
+        assertEquals("wheels", profile.name());
+    }
+
+    @Test
+    void forBinaryName_returnsDefaultProfileForLucli() {
+        CliProfile profile = CliProfile.forBinaryName("lucli");
+        assertInstanceOf(DefaultProfile.class, profile);
+        assertEquals("lucli", profile.name());
+        assertEquals(".lucli", profile.homeDirName());
+        assertEquals("cfml", profile.promptPrefix());
+        assertEquals("LuCLI", profile.displayName());
+    }
+
+    @Test
+    void forBinaryName_returnsDefaultProfileForNull() {
+        CliProfile profile = CliProfile.forBinaryName(null);
+        assertInstanceOf(DefaultProfile.class, profile);
+    }
+
+    @Test
+    void forBinaryName_returnsDefaultProfileForUnknown() {
+        CliProfile profile = CliProfile.forBinaryName("someothertool");
+        assertInstanceOf(DefaultProfile.class, profile);
+    }
+
+    @Test
+    void defaultProfile_bannerContainsLuCLI() {
+        DefaultProfile profile = new DefaultProfile();
+        // The banner should contain recognizable LuCLI ASCII art
+        assertTrue(profile.bannerText().contains("___ "));
+    }
+
+    @Test
+    void wheelsProfile_bannerContainsWheels() {
+        WheelsProfile profile = new WheelsProfile();
+        // The banner should contain recognizable Wheels ASCII art
+        assertTrue(profile.bannerText().contains("\\__ \\"));
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `CliProfile` interface with `forBinaryName()` factory that resolves the active profile from the binary name (`-Dlucli.binary.name` system property)
- `DefaultProfile` (LuCLI branding, `~/.lucli/`) and `WheelsProfile` (Wheels branding, `~/.wheels/`)
- Profile controls: `displayName()`, `homeDirName()`, `bannerText()`, `promptPrefix()`
- Wired into `LuCLI.main()` (profile resolution), `getBannerString()` (branding), `LucliPaths.resolve()` (home directory), and `ReplCommand` (prompt prefix)

## Motivation
When LuCLI is distributed as a renamed binary (e.g., `wheels`), the CLI should present itself with the host framework's branding. This enables frameworks like Wheels to ship LuCLI as their own CLI tool without exposing the underlying engine to developers.

Running as `wheels --version` now shows:
```
Wheels Version: x.x.x
 __        ___               _
 \ \      / / |__   ___  ___| |___
  \ \ /\ / /| '_ \ / _ \/ _ \ / __|
   \ V  V / | | | |  __/  __/ \__ \
    \_/\_/  |_| |_|\___|\___|_|___/
```

## Test plan
- [x] 7 tests for profile factory (wheels, lucli, null, unknown, case-insensitive, banner checks)
- [x] LucliPaths test isolation guard for profile-dependent home directory
- [x] 565 tests pass, 0 failures