### PR TITLE
feat: auto-detect and install JDBC drivers required by CFConfig datasources

### DIFF
--- a/src/main/java/org/lucee/lucli/server/JdbcDriverManager.java
+++ b/src/main/java/org/lucee/lucli/server/JdbcDriverManager.java
@@ -1,0 +1,196 @@
+package org.lucee.lucli.server;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * Manages automatic installation of JDBC drivers required by datasources
+ * defined in .CFConfig.json.
+ *
+ * <p>When a CFConfig datasource references a driver class that is not bundled
+ * with Lucee (e.g. {@code org.sqlite.JDBC}), this manager detects the
+ * requirement and downloads the JAR from Maven Central into the server's
+ * {@code lib/ext/} directory.</p>
+ */
+public final class JdbcDriverManager {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Descriptor for a known JDBC driver. */
+    public record DriverInfo(String className, String filePrefix, String downloadUrl, String fileName) {}
+
+    /**
+     * Registry of known JDBC drivers that are NOT bundled with Lucee and
+     * may need to be auto-installed. Expand this map as new drivers are
+     * needed.
+     */
+    private static final Map<String, DriverInfo> KNOWN_DRIVERS = Map.of(
+            "sqlite", new DriverInfo(
+                    "org.sqlite.JDBC",
+                    "sqlite-jdbc",
+                    "https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.49.1.0/sqlite-jdbc-3.49.1.0.jar",
+                    "sqlite-jdbc-3.49.1.0.jar"
+            )
+    );
+
+    private JdbcDriverManager() {
+        // Utility class — no instantiation
+    }
+
+    /**
+     * Parse a CFConfig JSON string, find datasources that reference a known
+     * driver class, and return the matching {@link DriverInfo} entries.
+     *
+     * <p>Drivers already bundled with Lucee (e.g. H2) are not in the
+     * registry and will be silently ignored.</p>
+     *
+     * @param cfConfigJson the raw JSON content of {@code .CFConfig.json}
+     * @return map of driver key to {@link DriverInfo} for each required
+     *         (non-bundled) driver; empty if none are needed or the JSON is
+     *         malformed
+     */
+    public static Map<String, DriverInfo> detectRequiredDrivers(String cfConfigJson) {
+        Map<String, DriverInfo> required = new HashMap<>();
+
+        try {
+            JsonNode root = MAPPER.readTree(cfConfigJson);
+            JsonNode datasources = root.path("datasources");
+            if (datasources.isMissingNode() || !datasources.isObject()) {
+                return required;
+            }
+
+            var it = datasources.fields();
+            while (it.hasNext()) {
+                var entry = it.next();
+                JsonNode dsNode = entry.getValue();
+                String driverClass = dsNode.path("class").asText("");
+
+                if (!driverClass.isEmpty()) {
+                    for (var known : KNOWN_DRIVERS.entrySet()) {
+                        if (known.getValue().className().equals(driverClass)) {
+                            required.put(known.getKey(), known.getValue());
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            // Malformed JSON — return empty, caller can proceed without auto-install
+        }
+
+        return required;
+    }
+
+    /**
+     * Check whether a JAR matching the given driver key's file prefix
+     * already exists in {@code libExtDir}.
+     *
+     * @param libExtDir the {@code lib/ext/} directory to scan
+     * @param driverKey a key from {@link #KNOWN_DRIVERS} (e.g. "sqlite")
+     * @return true if a matching JAR is found
+     */
+    public static boolean isDriverInstalled(Path libExtDir, String driverKey) {
+        DriverInfo info = KNOWN_DRIVERS.get(driverKey);
+        if (info == null || !Files.isDirectory(libExtDir)) {
+            return false;
+        }
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(libExtDir, info.filePrefix() + "*.jar")) {
+            return stream.iterator().hasNext();
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    /**
+     * Download a JDBC driver JAR from Maven Central and save it to
+     * {@code libExtDir}.
+     *
+     * @param libExtDir the {@code lib/ext/} directory to install into
+     * @param driverKey a key from {@link #KNOWN_DRIVERS}
+     * @throws IOException if the download or file write fails
+     */
+    public static void installDriver(Path libExtDir, String driverKey) throws IOException {
+        DriverInfo info = KNOWN_DRIVERS.get(driverKey);
+        if (info == null) {
+            throw new IllegalArgumentException("Unknown driver key: " + driverKey);
+        }
+
+        Files.createDirectories(libExtDir);
+        Path targetPath = libExtDir.resolve(info.fileName());
+
+        System.out.println("Downloading JDBC driver: " + info.fileName() + " ...");
+
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .followRedirects(HttpClient.Redirect.NORMAL)
+                    .connectTimeout(Duration.ofSeconds(15))
+                    .build();
+
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(info.downloadUrl()))
+                    .timeout(Duration.ofSeconds(60))
+                    .GET()
+                    .build();
+
+            HttpResponse<InputStream> response = client.send(request, HttpResponse.BodyHandlers.ofInputStream());
+
+            if (response.statusCode() != 200) {
+                throw new IOException("Failed to download " + info.downloadUrl() + " (HTTP " + response.statusCode() + ")");
+            }
+
+            try (InputStream body = response.body()) {
+                Files.copy(body, targetPath, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            System.out.println("Installed JDBC driver: " + targetPath);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IOException("Download interrupted for " + info.fileName(), e);
+        }
+    }
+
+    /**
+     * Orchestrator: detect required drivers from CFConfig, check which are
+     * already installed, and download any that are missing.
+     *
+     * @param libExtDir    the {@code lib/ext/} directory
+     * @param cfConfigJson the raw JSON content of {@code .CFConfig.json}
+     * @return true if any new drivers were installed (signals that the server
+     *         may need a restart to pick them up)
+     */
+    public static boolean ensureDrivers(Path libExtDir, String cfConfigJson) {
+        Map<String, DriverInfo> required = detectRequiredDrivers(cfConfigJson);
+        if (required.isEmpty()) {
+            return false;
+        }
+
+        boolean anyInstalled = false;
+        for (var entry : required.entrySet()) {
+            String key = entry.getKey();
+            if (!isDriverInstalled(libExtDir, key)) {
+                try {
+                    installDriver(libExtDir, key);
+                    anyInstalled = true;
+                } catch (IOException e) {
+                    System.err.println("Warning: Failed to install JDBC driver '" + key + "': " + e.getMessage());
+                }
+            }
+        }
+
+        return anyInstalled;
+    }
+}

--- a/src/main/java/org/lucee/lucli/server/runtime/LuceeExpressRuntimeProvider.java
+++ b/src/main/java/org/lucee/lucli/server/runtime/LuceeExpressRuntimeProvider.java
@@ -3,6 +3,7 @@ package org.lucee.lucli.server.runtime;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.lucee.lucli.server.JdbcDriverManager;
 import org.lucee.lucli.server.LuceeServerConfig;
 import org.lucee.lucli.server.LuceeServerManager;
 import org.lucee.lucli.server.TomcatConfigSupport;
@@ -57,6 +58,17 @@ public final class LuceeExpressRuntimeProvider implements RuntimeProvider {
 
         // Write CFConfig (.CFConfig.json) into the Lucee context if configured.
         LuceeServerConfig.writeCfConfigIfPresent(config, projectDir, catalinaBase);
+
+        // Auto-install JDBC drivers required by datasources in CFConfig
+        Path cfConfigPath = catalinaBase.resolve("lucee-server/context/.CFConfig.json");
+        if (Files.exists(cfConfigPath)) {
+            String cfConfigJson = Files.readString(cfConfigPath);
+            Path libExtDir = catalinaHome.resolve("lib/ext");
+            boolean driversInstalled = JdbcDriverManager.ensureDrivers(libExtDir, cfConfigJson);
+            if (driversInstalled) {
+                System.out.println("New JDBC drivers installed. They will be available on this server start.");
+            }
+        }
 
         // Deploy extension dependencies to lucee-server/deploy folder
         manager.deployExtensionsForServer(projectDir, catalinaBase);

--- a/src/test/java/org/lucee/lucli/server/JdbcDriverManagerTest.java
+++ b/src/test/java/org/lucee/lucli/server/JdbcDriverManagerTest.java
@@ -1,0 +1,181 @@
+package org.lucee.lucli.server;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Unit tests for JdbcDriverManager.
+ *
+ * Tests detection of required JDBC drivers from CFConfig JSON and
+ * file-existence checks in lib/ext. Actual HTTP downloads are not
+ * tested here — installDriver is integration-tested manually.
+ */
+public class JdbcDriverManagerTest {
+
+    @TempDir
+    Path tempDir;
+
+    // ── detectRequiredDrivers ───────────────────────────────────────────
+
+    @Test
+    void detectsRequiredDrivers_fromCfConfig() {
+        String cfConfig = """
+                {
+                    "datasources": {
+                        "mydb": {
+                            "class": "org.sqlite.JDBC",
+                            "connectionString": "jdbc:sqlite:db/wheels.sqlite"
+                        },
+                        "h2db": {
+                            "class": "org.h2.Driver",
+                            "connectionString": "jdbc:h2:mem:test"
+                        }
+                    }
+                }
+                """;
+
+        Map<String, JdbcDriverManager.DriverInfo> required = JdbcDriverManager.detectRequiredDrivers(cfConfig);
+
+        assertEquals(1, required.size(), "Should detect only SQLite, not H2");
+        assertTrue(required.containsKey("sqlite"));
+        assertEquals("org.sqlite.JDBC", required.get("sqlite").className());
+    }
+
+    @Test
+    void detectsRequiredDrivers_noDatasources() {
+        String cfConfig = """
+                {
+                    "inspectTemplate": "once",
+                    "requestTimeout": "0,0,50,0"
+                }
+                """;
+
+        Map<String, JdbcDriverManager.DriverInfo> required = JdbcDriverManager.detectRequiredDrivers(cfConfig);
+
+        assertTrue(required.isEmpty(), "No datasources should yield empty map");
+    }
+
+    @Test
+    void detectsRequiredDrivers_emptyJson() {
+        Map<String, JdbcDriverManager.DriverInfo> required = JdbcDriverManager.detectRequiredDrivers("{}");
+        assertTrue(required.isEmpty());
+    }
+
+    @Test
+    void detectsRequiredDrivers_malformedJson() {
+        Map<String, JdbcDriverManager.DriverInfo> required = JdbcDriverManager.detectRequiredDrivers("not json");
+        assertTrue(required.isEmpty(), "Malformed JSON should return empty map, not throw");
+    }
+
+    @Test
+    void detectsRequiredDrivers_multipleSqliteDatasources() {
+        String cfConfig = """
+                {
+                    "datasources": {
+                        "db1": { "class": "org.sqlite.JDBC", "connectionString": "jdbc:sqlite:a.db" },
+                        "db2": { "class": "org.sqlite.JDBC", "connectionString": "jdbc:sqlite:b.db" }
+                    }
+                }
+                """;
+
+        Map<String, JdbcDriverManager.DriverInfo> required = JdbcDriverManager.detectRequiredDrivers(cfConfig);
+
+        assertEquals(1, required.size(), "Duplicate driver class should yield single entry");
+        assertTrue(required.containsKey("sqlite"));
+    }
+
+    // ── isDriverInstalled ───────────────────────────────────────────────
+
+    @Test
+    void isDriverInstalled_falseWhenMissing() throws IOException {
+        Path libExtDir = tempDir.resolve("lib/ext");
+        Files.createDirectories(libExtDir);
+
+        assertFalse(JdbcDriverManager.isDriverInstalled(libExtDir, "sqlite"));
+    }
+
+    @Test
+    void isDriverInstalled_trueWhenPresent() throws IOException {
+        Path libExtDir = tempDir.resolve("lib/ext");
+        Files.createDirectories(libExtDir);
+        // Create a fake JAR matching the sqlite-jdbc prefix
+        Files.createFile(libExtDir.resolve("sqlite-jdbc-3.49.1.0.jar"));
+
+        assertTrue(JdbcDriverManager.isDriverInstalled(libExtDir, "sqlite"));
+    }
+
+    @Test
+    void isDriverInstalled_trueForDifferentVersion() throws IOException {
+        Path libExtDir = tempDir.resolve("lib/ext");
+        Files.createDirectories(libExtDir);
+        // Different version should still match the prefix
+        Files.createFile(libExtDir.resolve("sqlite-jdbc-3.40.0.0.jar"));
+
+        assertTrue(JdbcDriverManager.isDriverInstalled(libExtDir, "sqlite"));
+    }
+
+    @Test
+    void isDriverInstalled_falseForUnknownDriver() throws IOException {
+        Path libExtDir = tempDir.resolve("lib/ext");
+        Files.createDirectories(libExtDir);
+
+        assertFalse(JdbcDriverManager.isDriverInstalled(libExtDir, "nonexistent"));
+    }
+
+    @Test
+    void isDriverInstalled_falseWhenDirectoryMissing() {
+        Path libExtDir = tempDir.resolve("lib/ext/does-not-exist");
+
+        assertFalse(JdbcDriverManager.isDriverInstalled(libExtDir, "sqlite"));
+    }
+
+    // ── ensureDrivers ───────────────────────────────────────────────────
+
+    @Test
+    void ensureDrivers_skipsAlreadyInstalled() throws IOException {
+        Path libExtDir = tempDir.resolve("lib/ext");
+        Files.createDirectories(libExtDir);
+        // Pre-install the driver
+        Files.createFile(libExtDir.resolve("sqlite-jdbc-3.49.1.0.jar"));
+
+        String cfConfig = """
+                {
+                    "datasources": {
+                        "mydb": {
+                            "class": "org.sqlite.JDBC",
+                            "connectionString": "jdbc:sqlite:test.db"
+                        }
+                    }
+                }
+                """;
+
+        boolean installed = JdbcDriverManager.ensureDrivers(libExtDir, cfConfig);
+
+        assertFalse(installed, "Should not report new installations when driver already present");
+    }
+
+    @Test
+    void ensureDrivers_returnsFalseWhenNoDriversNeeded() throws IOException {
+        Path libExtDir = tempDir.resolve("lib/ext");
+        Files.createDirectories(libExtDir);
+
+        String cfConfig = """
+                {
+                    "datasources": {
+                        "h2db": { "class": "org.h2.Driver", "connectionString": "jdbc:h2:mem:test" }
+                    }
+                }
+                """;
+
+        boolean installed = JdbcDriverManager.ensureDrivers(libExtDir, cfConfig);
+
+        assertFalse(installed, "H2 is bundled with Lucee, should not trigger install");
+    }
+}


### PR DESCRIPTION
## Summary
- Adds `JdbcDriverManager` utility that scans `.CFConfig.json` for datasources requiring non-bundled JDBC drivers and auto-downloads them to `lib/ext/`
- Currently supports SQLite JDBC (`sqlite-jdbc-3.49.1.0.jar` from Maven Central); registry is extensible via `KNOWN_DRIVERS` map
- Wired into `LuceeExpressRuntimeProvider.start()` — runs after CFConfig is written, before server starts
- Uses `java.net.http.HttpClient` with timeouts (15s connect, 60s request)
- Skips download if a matching JAR already exists (prefix-based glob detection)

## Motivation
SQLite is becoming the default database for Wheels development. Lucee Express doesn't bundle the SQLite JDBC driver, requiring manual download and placement into `lib/ext/`. This eliminates that manual step — if your `lucee.json` has a SQLite datasource, the driver is installed automatically on first server start.

## Test plan
- [x] 12 unit tests covering detection, installation check, and ensureDrivers orchestration
- [x] Tests cover: SQLite detection, H2 ignored (bundled), empty/malformed JSON, deduplication, version-agnostic glob matching
- [x] No network calls in tests — only detection and file-existence logic
- [x] 570 tests pass, 0 failures