### PR TITLE
Add server start/run --prewarm with docs and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: write
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -78,6 +80,8 @@ jobs:
     permissions:
       contents: read
       checks: write
+      pull-requests: write
+      issues: write
     strategy:
       fail-fast: false
       matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-
+- **CI Test Result Publishing Permissions:** Updated GitHub Actions test jobs to grant `pull-requests: write` and `issues: write` so `EnricoMi/publish-unit-test-result-action` can post PR comments without failing Linux unit/integration jobs with `403 Resource not accessible by integration`.
 - **Server Runtime Prewarm Flag (`--prewarm`):** Added `--prewarm` support to both `lucli server start` and `lucli server run` to pre-download runtime artifacts and exit without starting a server. LuCLI now prewarms Lucee Express for `lucee-express` runtime, prewarms Lucee JARs for `tomcat`/`jetty` runtimes, and reports a no-download message for `docker` runtime.
 - **Server Header Shows Generated Lucee Config Path:** When server startup writes `.CFConfig.json`, LuCLI now prints `Generated lucee config in: <path>` alongside existing startup header lines so the effective Lucee config file location is explicit.
 - **Fix: Profile-Aware Home Directory in Script Engine:** `LuceeScriptEngine.getLucliHomeDirectory()` now uses the active CLI profile's home directory instead of a hardcoded `~/.lucli` path. This ensures that `BaseModule.cfc` and other shared resources are provisioned to the correct home directory (e.g. `~/.wheels/modules/` when running as `wheels`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- **Server Runtime Prewarm Flag (`--prewarm`):** Added `--prewarm` support to both `lucli server start` and `lucli server run` to pre-download runtime artifacts and exit without starting a server. LuCLI now prewarms Lucee Express for `lucee-express` runtime, prewarms Lucee JARs for `tomcat`/`jetty` runtimes, and reports a no-download message for `docker` runtime.
+- **Server Header Shows Generated Lucee Config Path:** When server startup writes `.CFConfig.json`, LuCLI now prints `Generated lucee config in: <path>` alongside existing startup header lines so the effective Lucee config file location is explicit.
 - **Server Environment Fallback (`LUCLI_ENV`) + Docker Default:** `lucli server start` and `lucli server run` now fall back to `LUCLI_ENV` when `--env/--environment` is not provided, while still honoring explicit `--env` precedence. The Docker image now sets `LUCLI_ENV=""` by default so deployments can override it at runtime (for example `docker run -e LUCLI_ENV=prod ...`).
 - **Server Warmup Flag (`--warmup`):** Added `--warmup` support to `lucli server start` and `lucli server run` to enable Lucee build-time warmup by injecting both `LUCEE_ENABLE_WARMUP=true` and `-Dlucee.enable.warmup=true` for that invocation (without persisting changes to `lucee.json`).
 - **`#project:path#` Placeholder in Configuration:** Added `#project:path#` placeholder support for `lucee.json` configuration values (e.g. datasource DSNs). Resolved at server start alongside `#env:VAR#` and `#secret:NAME#`, replacing the token with the absolute project directory path.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -55,3 +55,11 @@ Append new entries at the bottom under the appropriate date/session.
 ## 2026-04-10
 
 - Server lifecycle commands should resolve environment with explicit-first precedence: `--env/--environment` on `server start/run` wins, and only when missing should command handling fall back to `LuCLI.getCurrentEnvironment()` (which includes `LUCLI_ENV`).
+
+## 2026-04-14
+
+- `LuceeServerConfig.writeCfConfigIfPresent(...)` is the common write path used across runtime providers (`lucee-express`, `tomcat`, `jetty`) and sandbox flows, so startup messaging about generated `.CFConfig.json` should be emitted there to stay consistent for `server start` and `server run`.
+
+## 2026-04-15
+
+- Adding or changing `server` CLI flags requires updating multiple surfaces in sync: Picocli options in `src/main/java/org/lucee/lucli/cli/commands/ServerCommand.java`, manual parser logic in `src/main/java/org/lucee/lucli/server/ServerCommandHandler.java`, terminal completion metadata in `src/main/java/org/lucee/lucli/LucliCompleter.java`, and human-readable help text in `src/main/resources/text/server-help.txt`.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -63,3 +63,4 @@ Append new entries at the bottom under the appropriate date/session.
 ## 2026-04-15
 
 - Adding or changing `server` CLI flags requires updating multiple surfaces in sync: Picocli options in `src/main/java/org/lucee/lucli/cli/commands/ServerCommand.java`, manual parser logic in `src/main/java/org/lucee/lucli/server/ServerCommandHandler.java`, terminal completion metadata in `src/main/java/org/lucee/lucli/LucliCompleter.java`, and human-readable help text in `src/main/resources/text/server-help.txt`.
+- In GitHub Actions, `EnricoMi/publish-unit-test-result-action` can create checks with `checks: write` but PR comment publishing still requires additional token scope; add `pull-requests: write` and `issues: write` at the job level (or disable comments) to avoid `403 Resource not accessible by integration` on PR runs.

--- a/content/docs/050_server-configuration/040_runtime-providers.md
+++ b/content/docs/050_server-configuration/040_runtime-providers.md
@@ -13,6 +13,22 @@ LuCLI supports multiple runtime providers for running your CFML applications. Th
 | **External Tomcat** | Production, enterprise | 7.x for Tomcat 10+, 6.x for Tomcat 9 | Medium |
 | **Docker** *(experimental)* | Containers, CI/CD | Determined by image | Low |
 
+### Prewarm runtime downloads (no server start)
+
+If you need to cache runtime downloads before startup (for example in CI images), use:
+
+```bash
+lucli server start --prewarm
+```
+
+LuCLI resolves your runtime from `lucee.json` and then:
+
+- **Lucee Express runtime**: downloads/caches Lucee Express to `~/.lucli/express/<version>/`
+- **External Tomcat/Jetty runtime**: downloads/caches Lucee JARs to `~/.lucli/jars/`
+- **Docker runtime**: reports that no Lucee Express/JAR download is required
+
+`--prewarm` exits without starting a server process.
+
 ## Lucee Express (Default)
 
 Lucee Express bundles Tomcat and Lucee together in a single download. This is the default runtime and requires no configuration.

--- a/content/docs/060_server-lifecycle/010_starting-servers.md
+++ b/content/docs/060_server-lifecycle/010_starting-servers.md
@@ -100,6 +100,32 @@ lucli server start --version 6.2.2.91
 
 The chosen version is recorded in `lucee.json` under `version`. LuCLI downloads the engine the first time it is needed, then reuses the cached copy for subsequent starts.
 
+## Prewarm runtime artifacts (`--prewarm`)
+
+Use `--prewarm` when you want LuCLI to download/cache runtime artifacts ahead of time without actually starting a server process.
+
+```bash
+# Prewarm using current lucee.json/runtime settings
+lucli server start --prewarm
+
+# Prewarm with a one-shot version override
+lucli server run --prewarm --version 7.0.1.100-RC
+```
+
+What `--prewarm` does:
+
+- Loads `lucee.json`, applies `--env` (or `LUCLI_ENV` fallback), and applies one-shot overrides such as `--version`.
+- Downloads and caches what that runtime needs.
+- Exits successfully without launching Tomcat/Jetty or creating a running server instance.
+
+Runtime-specific behavior:
+
+- `runtime.type=lucee-express`: pre-downloads/caches Lucee Express under `~/.lucli/express/<version>/`
+- `runtime.type=tomcat` or `runtime.type=jetty`: pre-downloads/caches the Lucee JAR under `~/.lucli/jars/`
+- `runtime.type=docker`: no Lucee Express/JAR download is required, so LuCLI reports that no runtime artifact download is needed
+
+`--prewarm` is intended for CI/build pipelines or container images where you want startup-time downloads to happen earlier in the build stage.
+
 ## Environments (`--env`)
 
 You can define environments (such as `dev`, `staging`, `prod`) in the `environments` section of `lucee.json` and select one at startup:

--- a/content/docs/140_reference-and-examples/010_command-reference.md
+++ b/content/docs/140_reference-and-examples/010_command-reference.md
@@ -179,6 +179,7 @@ lucli start [OPTIONS]
 | `-c, --config` | Configuration file to use (defaults to lucee.json) |
 | `--env, --environment` | Environment to use (e.g., prod, dev, staging) |
 | `--dry-run` | Show configuration without starting the server |
+| `--prewarm` | Download/cache runtime artifacts and exit without starting a server |
 | `--include-lucee` | Include Lucee CFConfig in dry-run output |
 | `--include-tomcat-web` | Include Tomcat web.xml in dry-run output |
 | `--include-tomcat-server` | Include Tomcat server.xml in dry-run output |
@@ -214,6 +215,7 @@ lucli start [OPTIONS]
 | `-c, --config` | Configuration file to use (defaults to lucee.json) |
 | `--env, --environment` | Environment to use (e.g., prod, dev, staging) |
 | `--dry-run` | Show configuration without starting the server |
+| `--prewarm` | Download/cache runtime artifacts and exit without starting a server |
 | `--include-lucee` | Include Lucee CFConfig in dry-run output |
 | `--include-tomcat-web` | Include Tomcat web.xml in dry-run output |
 | `--include-tomcat-server` | Include Tomcat server.xml in dry-run output |
@@ -248,6 +250,7 @@ lucli run [OPTIONS]
 | `-f, --force` | Force replace existing server with same name |
 | `-c, --config` | Configuration file to use (defaults to lucee.json) |
 | `--env, --environment` | Environment to use (e.g., prod, dev, staging) |
+| `--prewarm` | Download/cache runtime artifacts and exit without starting a server |
 | `--no-agents` | Disable all Java agents |
 | `--agents` | Comma-separated list of agent IDs to include |
 | `--enable-agent` | Enable a specific agent by ID (repeatable) |

--- a/content/docs/140_reference-and-examples/030_common-workflows.md
+++ b/content/docs/140_reference-and-examples/030_common-workflows.md
@@ -108,6 +108,23 @@ See the [Modules](../040_cfml-execution/040_modules/) page for more on module st
 
 For full agent configuration options, see [Server Agents](../090_monitoring-and-agents/020_server-agents/).
 
+## Prewarm runtime artifacts in CI/container builds
+
+Use `--prewarm` during your build stage so runtime downloads are cached before the container/app starts.
+
+```bash
+# Build/CI step: resolve config + env, cache runtime artifacts, do not start server
+lucli server start --prewarm --env=prod
+```
+
+Then, at runtime, start normally:
+
+```bash
+lucli server start --env=prod
+```
+
+This helps avoid first-request startup delays caused by downloading Lucee artifacts when the container boots.
+
 ## Typical development loop
 
 A common day‑to‑day loop looks like:

--- a/src/main/java/org/lucee/lucli/LucliCompleter.java
+++ b/src/main/java/org/lucee/lucli/LucliCompleter.java
@@ -501,7 +501,7 @@ public class LucliCompleter implements Completer {
         
         if (words.size() == 2) {
             // Complete server subcommands
-            String[] serverSubcommands = {"start", "stop", "status", "list", "prune", "config", "lock", "unlock", "monitor", "log", "debug"};
+            String[] serverSubcommands = {"start", "run", "stop", "status", "list", "prune", "config", "lock", "unlock", "monitor", "log", "debug"};
             String partial = words.get(1);
             
             for (String subcommand : serverSubcommands) {
@@ -600,6 +600,8 @@ public class LucliCompleter implements Completer {
         switch (subcommand.toLowerCase()) {
             case "start":
                 return "Start a Lucee server";
+            case "run":
+                return "Run a Lucee server in foreground";
             case "stop":
                 return "Stop a running server";
             case "status":
@@ -632,6 +634,8 @@ public class LucliCompleter implements Completer {
         switch (subcommand.toLowerCase()) {
             case "start":
                 return "🚀";
+            case "run":
+                return "🏃";
             case "stop":
                 return "🛑";
             case "status":
@@ -694,7 +698,10 @@ public class LucliCompleter implements Completer {
         
         switch (subcommand.toLowerCase()) {
             case "start":
-                flags = new String[]{"--version", "--name", "--force", "--webroot", "-v", "-n", "-f"};
+                flags = new String[]{"--version", "--name", "--force", "--webroot", "--prewarm", "-v", "-n", "-f"};
+                break;
+            case "run":
+                flags = new String[]{"--version", "--name", "--force", "--webroot", "--prewarm", "-v", "-n", "-f"};
                 break;
             case "stop":
                 flags = new String[]{"--name", "--config", "--all", "-n", "-c"};
@@ -762,6 +769,8 @@ public class LucliCompleter implements Completer {
             case "--force":
             case "-f":
                 return "Force replace existing server";
+            case "--prewarm":
+                return "Download runtime artifacts and exit without starting";
             case "--all":
             case "-a":
                 return "Apply to all servers";

--- a/src/main/java/org/lucee/lucli/cli/commands/ServerCommand.java
+++ b/src/main/java/org/lucee/lucli/cli/commands/ServerCommand.java
@@ -181,6 +181,9 @@ public class ServerCommand implements Callable<Integer> {
         @Option(names = {"--warmup"},
                 description = "Enable Lucee warmup for this start (sets LUCEE_ENABLE_WARMUP=true and -Dlucee.enable.warmup=true)")
         private boolean warmup = false;
+        @Option(names = {"--prewarm"},
+                description = "Pre-download runtime artifacts (Lucee Express/JAR) and exit without starting the server")
+        private boolean prewarm = false;
 
         @Option(names = {"--webroot"},
                 description = "Override webroot (relative to project directory, like lucee.json)")
@@ -342,6 +345,9 @@ public class ServerCommand implements Callable<Integer> {
             if (warmup) {
                 args.add("--warmup");
             }
+            if (prewarm) {
+                args.add("--prewarm");
+            }
 
             if (sandbox) {
                 args.add("--sandbox");
@@ -418,6 +424,9 @@ public class ServerCommand implements Callable<Integer> {
         @Option(names = {"--warmup"},
                 description = "Enable Lucee warmup for this run (sets LUCEE_ENABLE_WARMUP=true and -Dlucee.enable.warmup=true)")
         private boolean warmup = false;
+        @Option(names = {"--prewarm"},
+                description = "Pre-download runtime artifacts (Lucee Express/JAR) and exit without starting the server")
+        private boolean prewarm = false;
 
         @Option(names = {"--no-agents"},
                 description = "Disable all Java agents")
@@ -516,6 +525,9 @@ public class ServerCommand implements Callable<Integer> {
             }
             if (warmup) {
                 args.add("--warmup");
+            }
+            if (prewarm) {
+                args.add("--prewarm");
             }
             if (sandbox) {
                 args.add("--sandbox");

--- a/src/main/java/org/lucee/lucli/server/LuceeServerConfig.java
+++ b/src/main/java/org/lucee/lucli/server/LuceeServerConfig.java
@@ -2446,6 +2446,7 @@ public class LuceeServerConfig {
         }
 
         objectMapper.writeValue(cfConfigPath.toFile(), finalConfig);
+        System.out.println("Generated lucee config in: " + cfConfigPath);
 
         // Cleanup legacy nested location when present to avoid diverging CFConfig state.
         Path legacyCfConfigPath = resolveLegacyCfConfigPath(config, serverInstanceDir);

--- a/src/main/java/org/lucee/lucli/server/ServerCommandHandler.java
+++ b/src/main/java/org/lucee/lucli/server/ServerCommandHandler.java
@@ -120,6 +120,7 @@ public class ServerCommandHandler {
         String environment = null;
         String webrootOverride = null;
         boolean dryRun = false;
+        boolean prewarm = false;
         boolean includeEnv = false;
         boolean includeLuceeConfig = false;
         boolean includeTomcatWeb = false;
@@ -178,6 +179,8 @@ public class ServerCommandHandler {
                 }
             } else if (args[i].equals("--dry-run")) {
                 dryRun = true;
+            } else if (args[i].equals("--prewarm")) {
+                prewarm = true;
             } else if (args[i].equals("--include-env")) {
                 includeEnv = true;
             } else if (args[i].equals("--include-tomcat-web")) {
@@ -256,9 +259,14 @@ public class ServerCommandHandler {
 
         environment = resolveEnvironment(environment);
         // If sandbox mode is requested, disallow dry-run/preview flags which rely on lucee.json
-        if (sandbox && (dryRun || includeLuceeConfig || includeTomcatWeb || includeTomcatServer
+        if (sandbox && (dryRun || prewarm || includeLuceeConfig || includeTomcatWeb || includeTomcatServer
                 || includeHttpsKeystorePlan || includeHttpsRedirectRules || createConfig)) {
-            return formatOutput("❌ --sandbox cannot be combined with --dry-run, --create-config or preview flags (--include-*, --include-all).", true);
+            return formatOutput("❌ --sandbox cannot be combined with --dry-run, --prewarm, --create-config or preview flags (--include-*, --include-all).", true);
+        }
+
+        if (prewarm && (dryRun || createConfig || includeLuceeConfig || includeTomcatWeb || includeTomcatServer
+                || includeHttpsKeystorePlan || includeHttpsRedirectRules || includeEnv)) {
+            return formatOutput("❌ --prewarm cannot be combined with --dry-run, --create-config or preview flags (--include-*, --include-all).", true);
         }
 
         // --source/--dest are only meaningful together with --create-config
@@ -286,6 +294,13 @@ public class ServerCommandHandler {
 
         // Apply one-shot CLI overrides in memory for this invocation.
         LuceeServerManager.applyStartConfigOverrides(finalConfig, startConfigOverrides);
+
+        if (prewarm) {
+            if (versionOverride != null && !versionOverride.trim().isEmpty()) {
+                LuceeServerConfig.setLuceeVersion(finalConfig, versionOverride.trim());
+            }
+            return prewarmRuntimeArtifacts(serverManager, projectDir, finalConfig);
+        }
         
         // If create-config is requested, materialize the server configuration and exit without starting.
         if (createConfig) {
@@ -654,6 +669,7 @@ public class ServerCommandHandler {
         String webrootOverride = null;
         boolean sandbox = false;
         boolean dryRun = false;
+        boolean prewarm = false;
         boolean includeEnv = false;
         Integer portOverride = null;
         Boolean enableLuceeOverride = null;
@@ -698,6 +714,8 @@ public class ServerCommandHandler {
                 webrootOverride = arg.substring("--webroot=".length());
             } else if ("--dry-run".equals(arg)) {
                 dryRun = true;
+            } else if ("--prewarm".equals(arg)) {
+                prewarm = true;
             } else if ("--include-env".equals(arg)) {
                 includeEnv = true;
             } else if ("--sandbox".equals(arg)) {
@@ -743,13 +761,38 @@ public class ServerCommandHandler {
         
         environment = resolveEnvironment(environment);
         
-        // Disallow --dry-run with --sandbox
-        if (sandbox && dryRun) {
-            return formatOutput("❌ --sandbox cannot be combined with --dry-run.", true);
+        // Disallow --dry-run/--prewarm with --sandbox
+        if (sandbox && (dryRun || prewarm)) {
+            return formatOutput("❌ --sandbox cannot be combined with --dry-run or --prewarm.", true);
+        }
+
+        if (prewarm && (dryRun || includeEnv)) {
+            return formatOutput("❌ --prewarm cannot be combined with --dry-run or --include-env.", true);
         }
         
         LuceeServerManager.StartConfigOverrides startConfigOverrides =
             buildStartConfigOverrides(configOverrides, webrootOverride, portOverride, enableLuceeOverride, enableWarmupOverride);
+
+        if (prewarm) {
+            String cfgFile = configFileName != null ? configFileName : "lucee.json";
+            LuceeServerConfig.ServerConfig finalConfig = LuceeServerConfig.loadConfig(projectDir, cfgFile);
+
+            if (environment != null && !environment.trim().isEmpty()) {
+                try {
+                    finalConfig = LuceeServerConfig.applyEnvironment(finalConfig, environment, projectDir);
+                } catch (IllegalArgumentException e) {
+                    return formatOutput("❌ " + e.getMessage(), true);
+                }
+            }
+
+            LuceeServerManager.applyStartConfigOverrides(finalConfig, startConfigOverrides);
+
+            if (versionOverride != null && !versionOverride.trim().isEmpty()) {
+                LuceeServerConfig.setLuceeVersion(finalConfig, versionOverride.trim());
+            }
+
+            return prewarmRuntimeArtifacts(serverManager, projectDir, finalConfig);
+        }
         
         // If no agent-related flags were actually set, avoid passing a non-null overrides object
         if (!agentOverrides.disableAllAgents &&
@@ -867,6 +910,43 @@ public class ServerCommandHandler {
         overrides.enableLuceeOverride = enableLuceeOverride;
         overrides.enableWarmupOverride = enableWarmupOverride;
         return overrides.isEmpty() ? null : overrides;
+    }
+
+    private String prewarmRuntimeArtifacts(LuceeServerManager serverManager,
+                                           Path projectDir,
+                                           LuceeServerConfig.ServerConfig finalConfig) throws Exception {
+        LuceeServerConfig.RuntimeConfig runtimeConfig = LuceeServerConfig.getEffectiveRuntime(finalConfig);
+        String runtimeType = (runtimeConfig != null && runtimeConfig.type != null && !runtimeConfig.type.trim().isEmpty())
+                ? runtimeConfig.type.trim()
+                : "lucee-express";
+        String normalizedRuntimeType = runtimeType.toLowerCase(java.util.Locale.ROOT);
+
+        LuceeServerConfig.validateLuceeVersionSupportForRuntime(finalConfig, runtimeType);
+        String luceeVersion = LuceeServerConfig.getLuceeVersion(finalConfig);
+
+        StringBuilder result = new StringBuilder();
+        result.append("🔥 Prewarming runtime artifacts (no server start)...\n");
+        result.append("   Project:       ").append(projectDir).append("\n");
+        result.append("   Runtime:       ").append(runtimeType).append("\n");
+        result.append("   Lucee Version: ").append(luceeVersion).append("\n");
+
+        if ("tomcat".equals(normalizedRuntimeType) || "jetty".equals(normalizedRuntimeType)) {
+            String variant = LuceeServerConfig.getLuceeVariant(finalConfig);
+            Path jarPath = serverManager.ensureLuceeJar(luceeVersion, variant);
+            result.append("   Lucee Variant: ").append(variant).append("\n");
+            result.append("   Cached JAR:    ").append(jarPath).append("\n");
+        } else if ("docker".equals(normalizedRuntimeType)) {
+            result.append("   Runtime Cache: Docker runtime uses container images; no Lucee Express/JAR download needed.\n");
+        } else {
+            if (!"lucee-express".equals(normalizedRuntimeType)) {
+                result.append("   Note:          Unknown runtime type; using lucee-express artifact cache.\n");
+            }
+            Path expressPath = serverManager.ensureLuceeExpress(luceeVersion);
+            result.append("   Express Path:  ").append(expressPath).append("\n");
+        }
+
+        result.append("✅ Runtime prewarm complete. No server was started.\n");
+        return formatOutput(result.toString(), false);
     }
     
     /**

--- a/src/main/resources/text/server-help.txt
+++ b/src/main/resources/text/server-help.txt
@@ -10,10 +10,23 @@ Commands:
     --disable-lucee          Start as static server (enableLucee=false for this start)
     --enable-lucee           Explicitly enable Lucee CFML engine for this start
     --warmup                 Enable Lucee warmup mode for this start
+    --prewarm                Download runtime artifacts and exit without starting
     --agents LIST            Comma-separated agent IDs to enable for this start
     --enable-agent NAME      Enable a specific agent for this start
     --disable-agent NAME     Disable a specific agent for this start
     --no-agents              Disable all agents for this start
+  run [options]              Run a Lucee server in foreground (Ctrl+C to stop)
+    --version VERSION        Specify Lucee version
+    --name NAME              Specify custom server name
+    --force                  Replace existing server
+    --disable-lucee          Run as static server (enableLucee=false for this run)
+    --enable-lucee           Explicitly enable Lucee CFML engine for this run
+    --warmup                 Enable Lucee warmup mode for this run
+    --prewarm                Download runtime artifacts and exit without starting
+    --agents LIST            Comma-separated agent IDs to enable for this run
+    --enable-agent NAME      Enable a specific agent for this run
+    --disable-agent NAME     Disable a specific agent for this run
+    --no-agents              Disable all agents for this run
   stop [options]             Stop the server for the current directory
     --name NAME              Stop a specific server by name
     --config FILE            Resolve server name from an alternate config file
@@ -40,6 +53,7 @@ Examples:
   lucli server start --version 6.1.0.123        # Start server with specific version
   lucli server start --agents luceedebug        # Start with only the luceedebug agent enabled
   lucli server start --enable-agent luceedebug  # Enable luceedebug in addition to default agents
+  lucli server start --prewarm                  # Download runtime artifacts only (no start)
                                                 
   lucli server start --no-agents                # Start with all agents disabled
   lucli server stop                             # Stop the server for current directory

--- a/src/test/java/org/lucee/lucli/server/ServerCommandHandlerTest.java
+++ b/src/test/java/org/lucee/lucli/server/ServerCommandHandlerTest.java
@@ -125,6 +125,117 @@ class ServerCommandHandlerTest {
                 "Dry-run output should include one-shot key=value override");
         assertTrue(after.has("dependencies"), "Dependencies block must remain intact");
     }
+    @Test
+    void serverStartPrewarm_tomcatRuntimeUsesCachedJarAndDoesNotMutateLuceeJson() throws Exception {
+        Path configFile = tempDir.resolve("lucee.json");
+        Files.writeString(configFile, """
+            {
+              "name": "prewarm-tomcat-test",
+              "lucee": {
+                "version": "6.2.2.91",
+                "variant": "standard"
+              },
+              "runtime": {
+                "type": "tomcat"
+              },
+              "dependencies": {
+                "framework-three": {
+                  "version": "3.0.0",
+                  "mapping": "/framework-three",
+                  "installPath": "dependencies/framework-three"
+                }
+              }
+            }
+            """);
+
+        JsonNode before = MAPPER.readTree(Files.readString(configFile));
+
+        Path lucliHome = tempDir.resolve(".lucli-home-prewarm-tomcat");
+        Path cachedJar = lucliHome.resolve("jars").resolve("lucee-6.2.2.91.jar");
+        Files.createDirectories(cachedJar.getParent());
+        Files.writeString(cachedJar, "stub-jar");
+
+        String previousLucliHome = System.getProperty("lucli.home");
+        System.setProperty("lucli.home", lucliHome.toString());
+        try {
+            ServerCommandHandler handler = new ServerCommandHandler(true, tempDir);
+            String output = handler.executeCommand("server", new String[] {
+                    "start", "--prewarm"
+            });
+
+            JsonNode after = MAPPER.readTree(Files.readString(configFile));
+
+            assertEquals(before, after, "start --prewarm must not modify lucee.json");
+            assertNotNull(output);
+            assertTrue(output.contains("Runtime prewarm complete"),
+                    "Prewarm output should confirm completion");
+            assertTrue(output.contains("Runtime:       tomcat"),
+                    "Prewarm output should report tomcat runtime");
+            assertTrue(output.contains(cachedJar.toString()),
+                    "Prewarm output should include cached Lucee JAR path");
+            assertTrue(Files.exists(cachedJar), "Cached Lucee JAR should still exist after prewarm");
+        } finally {
+            if (previousLucliHome == null) {
+                System.clearProperty("lucli.home");
+            } else {
+                System.setProperty("lucli.home", previousLucliHome);
+            }
+        }
+    }
+
+    @Test
+    void serverRunPrewarm_versionOverrideUsesCachedExpressAndDoesNotMutateLuceeJson() throws Exception {
+        Path configFile = tempDir.resolve("lucee.json");
+        Files.writeString(configFile, """
+            {
+              "name": "prewarm-run-test",
+              "lucee": {
+                "version": "6.2.2.91"
+              },
+              "dependencies": {
+                "framework-four": {
+                  "version": "4.0.0",
+                  "mapping": "/framework-four",
+                  "installPath": "dependencies/framework-four"
+                }
+              }
+            }
+            """);
+
+        JsonNode before = MAPPER.readTree(Files.readString(configFile));
+
+        String overriddenVersion = "7.0.1.100-RC";
+        Path lucliHome = tempDir.resolve(".lucli-home-prewarm-run");
+        Path cachedExpressDir = lucliHome.resolve("express").resolve(overriddenVersion);
+        Files.createDirectories(cachedExpressDir);
+
+        String previousLucliHome = System.getProperty("lucli.home");
+        System.setProperty("lucli.home", lucliHome.toString());
+        try {
+            ServerCommandHandler handler = new ServerCommandHandler(true, tempDir);
+            String output = handler.executeCommand("server", new String[] {
+                    "run", "--prewarm", "--version", overriddenVersion
+            });
+
+            JsonNode after = MAPPER.readTree(Files.readString(configFile));
+
+            assertEquals(before, after, "run --prewarm must not modify lucee.json");
+            assertNotNull(output);
+            assertTrue(output.contains("Runtime prewarm complete"),
+                    "Prewarm output should confirm completion");
+            assertTrue(output.contains("Lucee Version: " + overriddenVersion),
+                    "Prewarm output should include the overridden Lucee version");
+            assertTrue(output.contains(cachedExpressDir.toString()),
+                    "Prewarm output should include cached Lucee Express path");
+            assertTrue(Files.exists(cachedExpressDir), "Cached Lucee Express directory should remain available");
+        } finally {
+            if (previousLucliHome == null) {
+                System.clearProperty("lucli.home");
+            } else {
+                System.setProperty("lucli.home", previousLucliHome);
+            }
+        }
+    }
 
     @Test
     void serverStartDryRun_usesGlobalEnvironmentFallbackWhenNoEnvFlag() throws Exception {


### PR DESCRIPTION
## Summary
- add `lucli server start/run --prewarm` so runtime artifacts can be cached without starting a server
- make prewarm runtime-aware (`lucee-express` cache, `tomcat/jetty` JAR cache, docker no-download message)
- add/adjust tests plus help/completion/changelog/docs updates, including CI/container workflow docs

## Testing
- `mvn test`
- `./tests/test-bats.sh`

## Artifacts
- Conversation: https://app.warp.dev/conversation/c5aec5bd-ebff-444a-b3f4-8f2532598e08

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it extends `server start/run` argument parsing and runtime selection logic, which could alter lifecycle behavior and flag compatibility edge cases across runtimes.
> 
> **Overview**
> Adds a new `lucli server start/run --prewarm` mode that loads config (including env/one-shot overrides), pre-downloads the required runtime artifacts, and exits without creating a running server; behavior is runtime-aware (Express cache, Tomcat/Jetty JAR cache, Docker no-op message).
> 
> Updates help text, autocompletion, docs, and JUnit tests to cover the new flag and its mutual-exclusion rules, and enhances startup output to print the generated `.CFConfig.json` path.
> 
> Adjusts GitHub Actions unit/integration test job permissions (`pull-requests: write`, `issues: write`) so `publish-unit-test-result-action` can post PR comments without 403 failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 122ed4d69ced6f934862e24733e30850041707c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->