### PR TITLE
fix(mcp): capture module output and add tool hiding convention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ All notable changes to this project will be documented in this file.
 - **Fix: Profile-Aware Home Directory in Script Engine:** `LuceeScriptEngine.getLucliHomeDirectory()` now uses the active CLI profile's home directory instead of a hardcoded `~/.lucli` path. This ensures that `BaseModule.cfc` and other shared resources are provisioned to the correct home directory (e.g. `~/.wheels/modules/` when running as `wheels`).
 - **Server Environment Fallback (`LUCLI_ENV`) + Docker Default:** `lucli server start` and `lucli server run` now fall back to `LUCLI_ENV` when `--env/--environment` is not provided, while still honoring explicit `--env` precedence. The Docker image now sets `LUCLI_ENV=""` by default so deployments can override it at runtime (for example `docker run -e LUCLI_ENV=prod ...`).
 - **Server Warmup Flag (`--warmup`):** Added `--warmup` support to `lucli server start` and `lucli server run` to enable Lucee build-time warmup by injecting both `LUCEE_ENABLE_WARMUP=true` and `-Dlucee.enable.warmup=true` for that invocation (without persisting changes to `lucee.json`).
+- **Fix: MCP Tool Output Capture:** `lucli mcp <module>` now correctly captures module `out()` / `err()` output into JSON-RPC response bodies. Previously, Lucee's `systemOutput()` bypassed `System.setOut()` redirection because it caches stream references at engine startup — so every MCP tool returned empty content to callers while output leaked to the terminal, contaminating the stdio protocol stream. `BaseModule` now uses `createObject("java", "java.lang.System").out.println(...)` for dynamic lookup that honors redirection.
+- **MCP Tool Hiding:** Public functions inherited from `BaseModule` (`init`, `getEnv`, `getSecret`, `verbose`, `getAbsolutePath`, `executeCommand`, `version`, `showHelp`) are now automatically excluded from MCP `tools/list` responses. Modules can additionally declare specific commands to hide with a new `mcpHiddenTools()` convention:
+
+    ```cfm
+    public array function mcpHiddenTools() {
+        return ["start", "stop", "console"];
+    }
+    ```
+
+    Hidden tools remain reachable as CLI subcommands — this is purely an MCP-surface filter for commands that are stateful, interactive, or otherwise inappropriate for autonomous agent use.
+- **Fix: BaseModule.cfc Dev Sync:** The shared `BaseModule.cfc` in the active profile's modules directory is now refreshed when its content differs from the JAR-bundled copy, instead of only when the LuCLI version number changes. Dev iterations that modify `src/main/resources/modules/BaseModule.cfc` now reach the installed copy without needing a formal version bump.
+- **`executeModuleAndReturn()` on `LuceeScriptEngine`:** Framework callers can now invoke a module function and capture its return value without triggering the legacy print-if-non-null CLI behavior. Used internally by MCP tool introspection.
 - **`#project:path#` Placeholder in Configuration:** Added `#project:path#` placeholder support for `lucee.json` configuration values (e.g. datasource DSNs). Resolved at server start alongside `#env:VAR#` and `#secret:NAME#`, replacing the token with the absolute project directory path.
 
 

--- a/src/main/java/org/lucee/lucli/LuceeScriptEngine.java
+++ b/src/main/java/org/lucee/lucli/LuceeScriptEngine.java
@@ -383,12 +383,11 @@ public class LuceeScriptEngine {
 
 
     /**
-     * Execute a module by name with arguments
-     * @param moduleName
-     * @param scriptArgs
-     * @throws Exception
+     * Execute a module function and return its result. The result is whatever
+     * the invoked function returned (or null). Callers that want the legacy
+     * "print-if-non-null" CLI behavior should use {@link #executeModule}.
      */
-    public void executeModule(String moduleName, String[] scriptArgs) throws Exception {
+    public Object executeModuleAndReturn(String moduleName, String[] scriptArgs) throws Exception {
         
             // Ensure shared BaseModule.cfc in ~/.lucli/modules matches this LuCLI version
             ensureBaseModuleUpToDate();
@@ -449,10 +448,19 @@ public class LuceeScriptEngine {
             }
             engine.eval(script);
             Object results = engine.get("results");
-            if(results !=null){
-                StringOutput.getInstance().println(results.toString());
-            }
             Timer.stop("Module Execution: " + moduleName);
+            return results;
+    }
+
+    /**
+     * Execute a module by name, printing its non-null return value via
+     * StringOutput (legacy CLI behavior).
+     */
+    public void executeModule(String moduleName, String[] scriptArgs) throws Exception {
+        Object results = executeModuleAndReturn(moduleName, scriptArgs);
+        if (results != null) {
+            StringOutput.getInstance().println(results.toString());
+        }
     }
 
     // /**

--- a/src/main/java/org/lucee/lucli/LuceeScriptEngine.java
+++ b/src/main/java/org/lucee/lucli/LuceeScriptEngine.java
@@ -1013,8 +1013,10 @@ public class LuceeScriptEngine {
     
     /**
      * Ensure the shared BaseModule.cfc in the active profile's modules directory
-     * is in sync with the version bundled in this LuCLI JAR. We pin the file to
-     * the LuCLI version, so it is only refreshed when LuCLI itself is upgraded.
+     * matches the copy bundled in this LuCLI JAR. Compared by byte-equality so
+     * dev iterations (modifying src/main/resources/modules/BaseModule.cfc)
+     * refresh the installed copy without needing a version bump. Cached in-JVM
+     * so the check runs once per process.
      */
     private void ensureBaseModuleUpToDate() {
         if (baseModuleEnsured) {
@@ -1022,57 +1024,42 @@ public class LuceeScriptEngine {
         }
 
         try {
-            // Resolve ~/.lucli/modules
             Path lucliHome = getLucliHomeDirectory();
             Path modulesDir = lucliHome.resolve("modules");
             Files.createDirectories(modulesDir);
-
-            // Determine current LuCLI version
-            String currentVersion = LuCLI.getVersion();
-            if (currentVersion == null || currentVersion.trim().isEmpty()) {
-                currentVersion = "unknown";
-            }
-
-            // Version marker file for BaseModule
-            Path versionFile = modulesDir.resolve(".BaseModule.version");
-            String storedVersion = null;
-            if (Files.exists(versionFile)) {
-                try {
-                    storedVersion = Files.readString(versionFile).trim();
-                } catch (IOException e) {
-                    if (isDebugMode()) {
-                        System.err.println("Warning: Failed to read BaseModule version file: " + e.getMessage());
-                    }
-                }
-            }
-
             Path targetBaseModule = modulesDir.resolve("BaseModule.cfc");
 
-            boolean needsUpdate = !Files.exists(targetBaseModule) || storedVersion == null || !storedVersion.equals(currentVersion);
+            // Read bundled BaseModule bytes from JAR
+            byte[] jarBytes;
+            try (java.io.InputStream is = LuceeScriptEngine.class.getResourceAsStream("/modules/BaseModule.cfc")) {
+                if (is == null) {
+                    if (isDebugMode()) {
+                        System.err.println("Warning: BaseModule.cfc resource not found in JAR");
+                    }
+                    return;
+                }
+                jarBytes = is.readAllBytes();
+            }
+
+            // Refresh on-disk copy when missing or content differs
+            boolean needsUpdate = true;
+            if (Files.exists(targetBaseModule)) {
+                byte[] diskBytes = Files.readAllBytes(targetBaseModule);
+                needsUpdate = !java.util.Arrays.equals(jarBytes, diskBytes);
+            }
 
             if (needsUpdate) {
-                // Copy BaseModule.cfc from JAR resources into ~/.lucli/modules
-                try (java.io.InputStream is = LuceeScriptEngine.class.getResourceAsStream("/modules/BaseModule.cfc")) {
-                    if (is == null) {
-                        if (isDebugMode()) {
-                            System.err.println("Warning: BaseModule.cfc resource not found in JAR");
-                        }
-                        return;
-                    }
-                    Files.copy(is, targetBaseModule, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                }
+                Files.write(targetBaseModule, jarBytes);
 
-                // Persist the LuCLI version this BaseModule.cfc is synced with
-                try {
-                    Files.writeString(versionFile, currentVersion + System.lineSeparator());
-                } catch (IOException e) {
-                    if (isDebugMode()) {
-                        System.err.println("Warning: Failed to write BaseModule version file: " + e.getMessage());
-                    }
+                // Clean up legacy version marker from previous sync scheme
+                Path legacyVersionFile = modulesDir.resolve(".BaseModule.version");
+                if (Files.exists(legacyVersionFile)) {
+                    try { Files.delete(legacyVersionFile); }
+                    catch (IOException ignored) { /* best-effort */ }
                 }
 
                 if (isVerboseMode()) {
-                    System.out.println("Synchronized ~/.lucli/modules/BaseModule.cfc for LuCLI version " + currentVersion);
+                    System.out.println("Synchronized " + targetBaseModule);
                 }
             }
         } catch (IOException e) {
@@ -1080,8 +1067,6 @@ public class LuceeScriptEngine {
                 System.err.println("Warning: Failed to ensure BaseModule.cfc is up to date: " + e.getMessage());
             }
         } finally {
-            // Avoid repeating the check within the same JVM; version-based
-            // marker ensures we refresh on future LuCLI upgrades.
             baseModuleEnsured = true;
         }
     }

--- a/src/main/java/org/lucee/lucli/cli/commands/McpCommand.java
+++ b/src/main/java/org/lucee/lucli/cli/commands/McpCommand.java
@@ -66,6 +66,20 @@ public class McpCommand implements Callable<Integer> {
 
     private final ObjectMapper mapper = new ObjectMapper();
 
+    /**
+     * Public functions inherited from BaseModule (or framework conventions
+     * like mcpHiddenTools) that are never exposed as MCP tools. Mirrors the
+     * exclusion used by BaseModule.cfc's showHelp(). Compared lowercase
+     * because Lucee normalizes function names to lowercase in metadata.
+     */
+    private static final java.util.Set<String> BASE_MODULE_INTERNALS =
+            java.util.Set.of(
+                    "init", "out", "err", "getenv", "verbose",
+                    "getsecret", "getabsolutepath", "executecommand",
+                    "version", "showhelp",
+                    "mcphiddentools"
+            );
+
     private boolean initialized = false;
     private String negotiatedProtocolVersion = null;
 
@@ -274,6 +288,11 @@ public class McpCommand implements Callable<Integer> {
 
             String name = getString(fn, "name");
             if (name == null || name.isBlank()) {
+                continue;
+            }
+
+            // Skip BaseModule internals and framework convention functions
+            if (BASE_MODULE_INTERNALS.contains(name.toLowerCase())) {
                 continue;
             }
 

--- a/src/main/java/org/lucee/lucli/cli/commands/McpCommand.java
+++ b/src/main/java/org/lucee/lucli/cli/commands/McpCommand.java
@@ -278,6 +278,9 @@ public class McpCommand implements Callable<Integer> {
     private List<Map<String, Object>> listToolsForModule(String mod) throws Exception {
         Array meta = LuceeScriptEngine.getInstance().getComponentMetadata("modules." + mod + ".Module");
 
+        // Per-module hidden list returned by optional mcpHiddenTools() function
+        java.util.Set<String> moduleHidden = getModuleHiddenTools(mod);
+
         List<Map<String, Object>> tools = new ArrayList<>();
         for (int i = 1; i <= meta.size(); i++) {
             Object itemObj = meta.get(i, null);
@@ -293,6 +296,11 @@ public class McpCommand implements Callable<Integer> {
 
             // Skip BaseModule internals and framework convention functions
             if (BASE_MODULE_INTERNALS.contains(name.toLowerCase())) {
+                continue;
+            }
+
+            // Skip module-declared hidden tools
+            if (moduleHidden.contains(name.toLowerCase())) {
                 continue;
             }
 
@@ -312,6 +320,43 @@ public class McpCommand implements Callable<Integer> {
         }
 
         return tools;
+    }
+
+    /**
+     * If the module defines a public `mcpHiddenTools()` function returning an
+     * array of tool names, return those names (lowercase). Otherwise empty.
+     *
+     * Invoked once per tools/list request. Stdout/stderr are briefly
+     * redirected to discard any incidental output from the invocation, since
+     * tools/list has no active MCP capture buffer.
+     */
+    private java.util.Set<String> getModuleHiddenTools(String mod) {
+        PrintStream origOut = System.out;
+        PrintStream origErr = System.err;
+        java.io.ByteArrayOutputStream sink = new java.io.ByteArrayOutputStream();
+        PrintStream silent = new PrintStream(sink, true, StandardCharsets.UTF_8);
+        try {
+            System.setOut(silent);
+            System.setErr(silent);
+            Object result = LuceeScriptEngine.getInstance()
+                    .executeModuleAndReturn(mod, new String[] { "mcpHiddenTools" });
+            if (result instanceof Array) {
+                Array arr = (Array) result;
+                java.util.Set<String> hidden = new java.util.HashSet<>();
+                for (int i = 1; i <= arr.size(); i++) {
+                    Object v = arr.get(i, null);
+                    if (v != null) hidden.add(v.toString().toLowerCase());
+                }
+                return hidden;
+            }
+        } catch (Exception e) {
+            // Function may not exist on this module — that's fine.
+            if (LuCLI.debug) e.printStackTrace();
+        } finally {
+            System.setOut(origOut);
+            System.setErr(origErr);
+        }
+        return java.util.Collections.emptySet();
     }
 
     private Map<String, Object> buildInputSchema(Struct fn) {

--- a/src/main/resources/modules/BaseModule.cfc
+++ b/src/main/resources/modules/BaseModule.cfc
@@ -99,7 +99,10 @@ component {
         if(len(colour) || len(style)){
             message = "#style##colour##message##reset#";
         }
-        systemOutput(message, true, true);
+        // Use dynamic Java lookup so System.setOut(...) redirection is honored.
+        // Lucee's built-in systemOutput() caches stream references at engine
+        // startup and bypasses later setOut() calls — breaking MCP capture.
+        createObject("java", "java.lang.System").out.println(message);
     }
     // Could add colours here:
 
@@ -112,9 +115,8 @@ component {
         if(!isSimpleValue(message)){
             message = serializeJson(var=message, compact=false);
         }
-        // For CLI usage (including tight loops like watch()), write directly to
-        // system output so LuCLI can surface logs immediately.
-        systemOutput(message, true, false);
+        // Dynamic Java lookup — see rationale in out() above.
+        createObject("java", "java.lang.System").err.println(message);
     }
 
     

--- a/src/main/resources/modules/BaseModule.cfc
+++ b/src/main/resources/modules/BaseModule.cfc
@@ -266,7 +266,8 @@ component {
         // Functions from BaseModule to exclude from command listing
         var internalFunctions = [
             "init", "showhelp", "out", "err", "getenv", "verbose",
-            "getsecret", "getabsolutepath", "executecommand", "version"
+            "getsecret", "getabsolutepath", "executecommand", "version",
+            "mcphiddentools"
         ];
 
         // Collect public command functions

--- a/src/test/java/org/lucee/lucli/cli/commands/McpCommandTest.java
+++ b/src/test/java/org/lucee/lucli/cli/commands/McpCommandTest.java
@@ -1,0 +1,177 @@
+package org.lucee.lucli.cli.commands;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.lucee.lucli.paths.LucliPaths;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Integration tests for {@link McpCommand}.
+ *
+ * Copies a small fixture module (src/test/resources/mcp-fixture-module) into
+ * the real LuCLI modules directory, spawns `dev-lucli.sh mcp mcpfixture` as a
+ * subprocess, and asserts on the JSON-RPC responses emitted on stdout.
+ *
+ * The fixture is removed in {@link #tearDown()}.
+ *
+ * <p>These tests require a Unix-like shell environment (bash) to invoke
+ * {@code dev-lucli.sh}. They are skipped on Windows — macOS and Ubuntu CI
+ * provide platform coverage.
+ */
+class McpCommandTest {
+
+    private static final String FIXTURE_MODULE_NAME = "mcpfixture";
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private static Path fixtureInstalledPath;
+    private static String lucliBin;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        // Subprocess-based tests need bash + dev-lucli.sh. Windows runners
+        // lack /bin/bash and ProcessBuilder doesn't resolve bash.exe via
+        // PATHEXT, so skip on Windows — macOS + Ubuntu CI cover the behavior.
+        Assumptions.assumeFalse(
+                System.getProperty("os.name").toLowerCase().contains("win"),
+                "McpCommandTest uses bash subprocess — skipped on Windows");
+
+        Path fixtureSrc = Path.of("src/test/resources/mcp-fixture-module")
+                .toAbsolutePath();
+        assertTrue(Files.isDirectory(fixtureSrc),
+                "fixture source not found at " + fixtureSrc);
+
+        Path modulesDir = LucliPaths.resolve().modulesDir();
+        Files.createDirectories(modulesDir);
+        fixtureInstalledPath = modulesDir.resolve(FIXTURE_MODULE_NAME);
+
+        if (Files.exists(fixtureInstalledPath)) {
+            deleteRecursively(fixtureInstalledPath);
+        }
+        copyDirectory(fixtureSrc, fixtureInstalledPath);
+
+        File devBin = new File("dev-lucli.sh");
+        assertTrue(devBin.exists(),
+                "dev-lucli.sh must be run from LuCLI repo root");
+        lucliBin = devBin.getAbsolutePath();
+    }
+
+    @AfterAll
+    static void tearDown() throws Exception {
+        if (fixtureInstalledPath != null && Files.exists(fixtureInstalledPath)) {
+            deleteRecursively(fixtureInstalledPath);
+        }
+    }
+
+    @Test
+    void toolCallCapturesOutStreamIntoResponseBody() throws Exception {
+        List<JsonNode> responses = runMcpSession(List.of(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}",
+            "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}",
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"echo\",\"arguments\":{}}}"
+        ));
+
+        JsonNode callResp = responses.stream()
+                .filter(n -> n.has("id") && n.get("id").asInt() == 2)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "no response for id=2. Responses: " + responses));
+
+        assertTrue(callResp.has("result"), "expected result, got: " + callResp);
+        JsonNode content = callResp.get("result").get("content");
+        assertNotNull(content);
+        assertEquals(1, content.size());
+
+        String text = content.get(0).get("text").asText();
+        assertTrue(text.contains("hello from echo"),
+                "expected captured output in response, got: '" + text + "'");
+    }
+
+    // Send the given JSON-RPC lines to `dev-lucli.sh mcp mcpfixture` as a
+    // subprocess. Returns each parsed response as a JsonNode.
+    private List<JsonNode> runMcpSession(List<String> requests) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder(
+                "/bin/bash", lucliBin, "mcp", FIXTURE_MODULE_NAME);
+        pb.redirectErrorStream(false);
+        Process proc = pb.start();
+
+        try (BufferedWriter stdin = new BufferedWriter(
+                new OutputStreamWriter(proc.getOutputStream(), StandardCharsets.UTF_8))) {
+            for (String req : requests) {
+                stdin.write(req);
+                stdin.newLine();
+                stdin.flush();
+            }
+        }
+
+        List<JsonNode> responses = new ArrayList<>();
+        try (BufferedReader stdout = new BufferedReader(
+                new InputStreamReader(proc.getInputStream(), StandardCharsets.UTF_8))) {
+            String line;
+            while ((line = stdout.readLine()) != null) {
+                if (line.isBlank()) continue;
+                try {
+                    responses.add(MAPPER.readTree(line));
+                } catch (Exception e) {
+                    // Non-JSON line (maven progress, etc.) — skip
+                }
+            }
+        }
+        proc.waitFor(120, TimeUnit.SECONDS);
+        return responses;
+    }
+
+    private static void copyDirectory(Path src, Path dest) throws IOException {
+        Files.createDirectories(dest);
+        try (Stream<Path> stream = Files.walk(src)) {
+            stream.forEach(source -> {
+                try {
+                    Path target = dest.resolve(src.relativize(source));
+                    if (Files.isDirectory(source)) {
+                        Files.createDirectories(target);
+                    } else {
+                        Files.copy(source, target, StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            });
+        }
+    }
+
+    private static void deleteRecursively(Path path) throws IOException {
+        if (!Files.exists(path)) return;
+        try (Stream<Path> stream = Files.walk(path)) {
+            stream.sorted(Comparator.reverseOrder())
+                  .forEach(p -> {
+                      try { Files.delete(p); }
+                      catch (IOException e) { throw new RuntimeException(e); }
+                  });
+        }
+    }
+
+}

--- a/src/test/java/org/lucee/lucli/cli/commands/McpCommandTest.java
+++ b/src/test/java/org/lucee/lucli/cli/commands/McpCommandTest.java
@@ -111,6 +111,41 @@ class McpCommandTest {
                 "expected captured output in response, got: '" + text + "'");
     }
 
+    @Test
+    void toolsListExcludesBaseModuleInternals() throws Exception {
+        List<JsonNode> responses = runMcpSession(List.of(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}",
+            "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}",
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}"
+        ));
+
+        JsonNode listResp = responses.stream()
+                .filter(n -> n.has("id") && n.get("id").asInt() == 2)
+                .findFirst()
+                .orElseThrow();
+
+        // Lucee lowercases function names in metadata — compare lowercase
+        List<String> names = new ArrayList<>();
+        listResp.get("result").get("tools").forEach(
+                t -> names.add(t.get("name").asText().toLowerCase()));
+
+        // BaseModule helpers must NOT leak into the tool list
+        List<String> forbidden = List.of(
+                "init", "out", "err", "getenv", "verbose",
+                "getsecret", "getabsolutepath", "executecommand",
+                "version", "showhelp", "mcphiddentools"
+        );
+        for (String banned : forbidden) {
+            assertFalse(names.contains(banned),
+                    "tool '" + banned + "' must be hidden from MCP. Got: " + names);
+        }
+
+        // Fixture tools must remain
+        assertTrue(names.contains("echo"), "expected echo. Got: " + names);
+        assertTrue(names.contains("boom"), "expected boom. Got: " + names);
+        assertTrue(names.contains("greet"), "expected greet. Got: " + names);
+    }
+
     // Send the given JSON-RPC lines to `dev-lucli.sh mcp mcpfixture` as a
     // subprocess. Returns each parsed response as a JsonNode.
     private List<JsonNode> runMcpSession(List<String> requests) throws Exception {

--- a/src/test/java/org/lucee/lucli/cli/commands/McpCommandTest.java
+++ b/src/test/java/org/lucee/lucli/cli/commands/McpCommandTest.java
@@ -146,6 +146,32 @@ class McpCommandTest {
         assertTrue(names.contains("greet"), "expected greet. Got: " + names);
     }
 
+    @Test
+    void toolsListHonorsMcpHiddenToolsDeclaration() throws Exception {
+        List<JsonNode> responses = runMcpSession(List.of(
+            "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"test\",\"version\":\"1.0\"}}}",
+            "{\"jsonrpc\":\"2.0\",\"method\":\"notifications/initialized\"}",
+            "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/list\",\"params\":{}}"
+        ));
+
+        JsonNode listResp = responses.stream()
+                .filter(n -> n.has("id") && n.get("id").asInt() == 2)
+                .findFirst()
+                .orElseThrow();
+
+        List<String> names = new ArrayList<>();
+        listResp.get("result").get("tools").forEach(
+                t -> names.add(t.get("name").asText().toLowerCase()));
+
+        // Fixture module declares mcpHiddenTools() returns ["secret"]
+        assertFalse(names.contains("secret"),
+                "tool 'secret' should be hidden via mcpHiddenTools(). Got: " + names);
+
+        // Other fixture tools remain visible
+        assertTrue(names.contains("echo"), "expected echo. Got: " + names);
+        assertTrue(names.contains("greet"), "expected greet. Got: " + names);
+    }
+
     // Send the given JSON-RPC lines to `dev-lucli.sh mcp mcpfixture` as a
     // subprocess. Returns each parsed response as a JsonNode.
     private List<JsonNode> runMcpSession(List<String> requests) throws Exception {

--- a/src/test/resources/mcp-fixture-module/Module.cfc
+++ b/src/test/resources/mcp-fixture-module/Module.cfc
@@ -1,0 +1,43 @@
+component extends="modules.BaseModule" {
+
+    /**
+     * hint: Emit a known string via out() — used to test MCP output capture.
+     */
+    public string function echo() {
+        out("hello from echo");
+        return "";
+    }
+
+    /**
+     * hint: Emit via err() — used to test error-stream capture.
+     */
+    public string function boom() {
+        err("hello from boom");
+        return "";
+    }
+
+    /**
+     * hint: Public tool that should appear in MCP tools/list.
+     * @subject Thing to greet
+     */
+    public string function greet(string subject = "world") {
+        out("hello, " & arguments.subject);
+        return "";
+    }
+
+    /**
+     * hint: Public tool that should be hidden from MCP tools/list via mcpHiddenTools().
+     */
+    public string function secret() {
+        out("should not be reachable via MCP");
+        return "";
+    }
+
+    /**
+     * hint: Declares which tools to hide from MCP discovery.
+     */
+    public array function mcpHiddenTools() {
+        return ["secret"];
+    }
+
+}

--- a/src/test/resources/mcp-fixture-module/module.json
+++ b/src/test/resources/mcp-fixture-module/module.json
@@ -1,0 +1,5 @@
+{
+    "name": "mcpfixture",
+    "version": "0.0.1",
+    "description": "Test fixture module for McpCommand integration tests"
+}


### PR DESCRIPTION
## Summary

Two related MCP reliability fixes plus a dev-workflow improvement:

1. **Output capture.** Lucee's `systemOutput()` caches `System.out` / `System.err` references at engine startup. `McpCommand` redirects those streams via `System.setOut(capture)`, but `systemOutput()` doesn't see the redirection — so every module tool returned empty text to MCP callers and leaked output to the terminal. Fixed by switching `BaseModule.out()` / `err()` to `createObject("java","java.lang.System")` dynamic lookup.

2. **Tool hiding.** `BaseModule` helpers (`init`, `out`, `err`, `getEnv`, etc.) were exposed as MCP tools alongside a module's real subcommands. Added an always-excluded list in `McpCommand`, plus an optional `mcpHiddenTools()` convention for per-module opt-outs:

    ```cfm
    public array function mcpHiddenTools() {
        return ["start", "stop", "console"];
    }
    ```

    Hidden tools remain reachable as CLI subcommands — this is purely an MCP-surface filter for commands that are stateful, interactive, or otherwise inappropriate for autonomous agent use.

3. **BaseModule dev sync.** `ensureBaseModuleUpToDate()` previously gated on LuCLI version number, so dev iterations that modified `src/main/resources/modules/BaseModule.cfc` didn't reach the installed `~/.lucli/modules/BaseModule.cfc` copy until a version bump. Switched to byte-equality comparison against the JAR-bundled copy.

## Why this matters

Before this fix, every MCP module built on LuCLI was functionally broken as an agent integration: tools could be discovered, but calling them returned empty content and leaked output to the terminal, contaminating the stdio protocol stream. Verified end-to-end against the Wheels module in a sandbox project — `info` tool now returns 245 chars of real output where it previously returned `\n`.

## Test plan

- [x] New `McpCommandTest` integration test class (3 tests) that spawns `dev-lucli.sh mcp mcpfixture` as a subprocess and asserts on JSON-RPC responses
- [x] `toolCallCapturesOutStreamIntoResponseBody` — red before fix, green after
- [x] `toolsListExcludesBaseModuleInternals` — validates internal filter + `mcpHiddenTools` self-hide
- [x] `toolsListHonorsMcpHiddenToolsDeclaration` — validates per-module opt-out
- [x] Full `mvn test` — 592 tests green, no regressions
- [x] Manual end-to-end smoke test: `mvn -f .../LuCLI/pom.xml exec:java` from a real Wheels project's dir, send JSON-RPC `tools/call info` → captured output returned in response content