### PR TITLE
Add performance benchmark workflow and README badge

### DIFF
--- a/.github/workflows/perf-benchmark.yml
+++ b/.github/workflows/perf-benchmark.yml
@@ -1,0 +1,111 @@
+name: Performance Benchmarks
+
+on:
+  workflow_dispatch:
+    inputs:
+      runs:
+        description: Number of measured runs per benchmark
+        required: false
+        default: "20"
+      warmup:
+        description: Number of warmup runs per benchmark
+        required: false
+        default: "3"
+      max_regression_pct:
+        description: Optional max allowed median regression percentage
+        required: false
+        default: ""
+  schedule:
+    - cron: "0 6 * * *"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/perf-benchmark.yml"
+      - "tests/perf/**"
+      - "tests/bats/12_perf_smoke.bats"
+      - "pom.xml"
+      - "src/**"
+
+jobs:
+  benchmark:
+    name: Benchmark Startup + CFML Now
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Cache Maven dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-21-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-m2-21-
+            ${{ runner.os }}-m2-
+
+      - name: Build JAR and binary
+        run: mvn clean package -DskipTests -Pbinary
+
+      - name: Run startup benchmarks
+        run: |
+          RUNS="${RUNS_INPUT:-20}"
+          WARMUP="${WARMUP_INPUT:-3}"
+          MAX_REGRESSION="${MAX_REGRESSION_INPUT:-}"
+
+          BENCHMARK_ARGS=(--runs "$RUNS" --warmup "$WARMUP" --output "tests/perf/benchmark-latest.json")
+          if [[ -n "${MAX_REGRESSION}" ]]; then
+            BENCHMARK_ARGS+=(--max-regression-pct "$MAX_REGRESSION")
+          fi
+
+          ./tests/perf/benchmark-startup.sh "${BENCHMARK_ARGS[@]}"
+        env:
+          RUNS_INPUT: ${{ github.event.inputs.runs }}
+          WARMUP_INPUT: ${{ github.event.inputs.warmup }}
+          MAX_REGRESSION_INPUT: ${{ github.event.inputs.max_regression_pct }}
+
+      - name: Publish benchmark summary
+        run: |
+          python3 - <<'PY'
+          import json
+          from pathlib import Path
+
+          data = json.loads(Path("tests/perf/benchmark-latest.json").read_text())
+          startup = data["results"]["startup_version"]
+          cfml_now = data["results"]["cfml_now"]
+
+          lines = [
+              "## Performance Benchmarks",
+              "",
+              f"- Runs: {data['runs']} (warmup: {data['warmup_runs']})",
+              "",
+              "### startup_version",
+              f"- median: {startup['median_ms']} ms",
+              f"- p95: {startup['p95_ms']} ms",
+              f"- mean: {startup['mean_ms']} ms",
+              "",
+              "### cfml_now",
+              f"- median: {cfml_now['median_ms']} ms",
+              f"- p95: {cfml_now['p95_ms']} ms",
+              f"- mean: {cfml_now['mean_ms']} ms",
+          ]
+
+          with open(Path(__import__('os').environ["GITHUB_STEP_SUMMARY"]), "a", encoding="utf-8") as f:
+              f.write("\n".join(lines) + "\n")
+          PY
+
+      - name: Upload benchmark artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: benchmark-results
+          path: tests/perf/benchmark-latest.json
+          retention-days: 30
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- **Benchmark Workflow + README Badge:** Added `.github/workflows/perf-benchmark.yml` to run startup/`cfml now()` benchmarks on schedule, manual dispatch, and relevant `main` pushes, publish a run summary, and upload benchmark JSON artifacts. Added a benchmark status badge to `README.md` linking to the new workflow.
+- **Performance Testing: BATS Perf Smoke + Benchmark Script:** Added `tests/bats/12_perf_smoke.bats` with conservative startup/simple-command latency smoke checks (`--version` and `cfml writeOutput(now())`) and a new `tests/perf/benchmark-startup.sh` script for repeatable multi-run benchmarking with JSON output, optional baseline comparison, and optional regression-threshold enforcement. BATS runners now default to `BATS_TEST_TIMEOUT=10`, server dry-run fixtures now use Lucee `7.0.4.34` with `variant: "zero"`, and `tests/test-bats.sh`/`tests/test.sh` prewarm a shared Lucee Express cache (`LUCLI_BATS_EXPRESS_CACHE_DIR`) so per-test temp homes avoid one-time runtime download delays.
 - **Script Env Flag Propagation (`LUCLI_ENV`):** When running LuCLI command scripts with `--env`, the resolved environment is now exposed in script `__env` as `LUCLI_ENV`. Added regression test coverage to verify script-level access.
 - **Release Workflow JReleaser Config Path:** Updated `.github/workflows/release.yml` to run `jreleaser:full-release` with `-Djreleaser.config.file=jreleaser.yml` so publishing uses the intended explicit JReleaser config.
 - **Repository Default CODEOWNERS:** Added a repository-level `CODEOWNERS` file that assigns `@cybersonic` as the default code owner.

--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -126,3 +126,9 @@ Append new entries at the bottom under the appropriate date/session.
 - To gate release publishing on the exact same validation matrix as normal CI, add `workflow_call` to `.github/workflows/ci.yml` and invoke that workflow from `release.yml` via `jobs.<name>.uses`, instead of duplicating unit/integration/build jobs.
 - In this repo, release publishing with JReleaser should not use `-Pbinary` because that profile bumps `project.version` to the next `*-SNAPSHOT`; build without `-Pbinary` and assemble launcher artifacts before running `jreleaser:full-release`.
 - Markspresso's `build` command treats extra positional tokens as source path input; `lucli markspresso build clean` resolves source as `./clean` and can break Pages builds. Use `lucli markspresso build` or explicit flags like `--clean true` instead.
+
+## 2026-06-19
+
+- For LuCLI performance coverage, keep BATS perf checks as coarse smoke guards with conservative, env-overridable thresholds (for example `LUCLI_PERF_SMOKE_VERSION_MS` and `LUCLI_PERF_SMOKE_CFML_NOW_MS`) to avoid flaky CI while still catching major regressions.
+- `BATS_TEST_TIMEOUT` applies to setup/teardown hooks too; expensive one-time runtime prep should happen in the runner (`tests/test-bats.sh` / `tests/test.sh`) rather than `setup_file`, otherwise hook prewarm can be killed as a timeout failure before any test runs.
+- For BATS suites that create fresh `LUCLI_HOME` sandboxes per test, exporting a shared express cache path (for example `LUCLI_BATS_EXPRESS_CACHE_DIR`) and symlinking it in `setup_lucli_home` avoids repeated Lucee runtime downloads while preserving per-test home isolation.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/cybersonic/LuCLI/actions/workflows/ci.yml/badge.svg)](https://github.com/cybersonic/LuCLI/actions/workflows/ci.yml)
 [![Release](https://github.com/cybersonic/LuCLI/actions/workflows/release.yml/badge.svg)](https://github.com/cybersonic/LuCLI/actions/workflows/release.yml)
 [![Docs](https://github.com/cybersonic/LuCLI/actions/workflows/static.yml/badge.svg)](https://github.com/cybersonic/LuCLI/actions/workflows/static.yml)
+[![Benchmarks](https://github.com/cybersonic/LuCLI/actions/workflows/perf-benchmark.yml/badge.svg)](https://github.com/cybersonic/LuCLI/actions/workflows/perf-benchmark.yml)
 [![Java 21+](https://img.shields.io/badge/java-21+-blue)](https://adoptium.net/)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Alpha](https://img.shields.io/badge/status-alpha-orange)](https://github.com/cybersonic/LuCLI/releases)

--- a/tests/perf/benchmark-startup.sh
+++ b/tests/perf/benchmark-startup.sh
@@ -1,0 +1,226 @@
+#!/bin/bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+LUCLI_JAR="${ROOT_DIR}/target/lucli.jar"
+LUCLI_BINARY="${ROOT_DIR}/target/lucli"
+
+RUNS=20
+WARMUP=3
+OUTPUT_FILE="${ROOT_DIR}/tests/perf/benchmark-latest.json"
+BASELINE_FILE=""
+MAX_REGRESSION_PCT=""
+
+usage() {
+    cat <<'EOF'
+Usage: tests/perf/benchmark-startup.sh [options]
+
+Runs repeatable latency benchmarks for:
+  1) startup/version command: lucli --version
+  2) simple CFML command:     lucli cfml 'writeOutput(now())'
+
+Options:
+  --runs <n>                  Number of measured runs per command (default: 20)
+  --warmup <n>                Number of warmup runs per command (default: 3)
+  --output <path>             JSON output file (default: tests/perf/benchmark-latest.json)
+  --baseline <path>           Baseline JSON to compare against
+  --max-regression-pct <pct>  Fail if any median latency regression exceeds pct
+  --help                      Show this help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --runs)
+            RUNS="$2"
+            shift 2
+            ;;
+        --warmup)
+            WARMUP="$2"
+            shift 2
+            ;;
+        --output)
+            OUTPUT_FILE="$2"
+            shift 2
+            ;;
+        --baseline)
+            BASELINE_FILE="$2"
+            shift 2
+            ;;
+        --max-regression-pct)
+            MAX_REGRESSION_PCT="$2"
+            shift 2
+            ;;
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+if ! [[ "${RUNS}" =~ ^[0-9]+$ ]] || [[ "${RUNS}" -le 0 ]]; then
+    echo "--runs must be a positive integer" >&2
+    exit 1
+fi
+
+if ! [[ "${WARMUP}" =~ ^[0-9]+$ ]] || [[ "${WARMUP}" -lt 0 ]]; then
+    echo "--warmup must be a non-negative integer" >&2
+    exit 1
+fi
+
+if [[ -n "${MAX_REGRESSION_PCT}" ]] && ! [[ "${MAX_REGRESSION_PCT}" =~ ^[0-9]+([.][0-9]+)?$ ]]; then
+    echo "--max-regression-pct must be a non-negative number" >&2
+    exit 1
+fi
+
+if [[ -n "${BASELINE_FILE}" && ! -f "${BASELINE_FILE}" ]]; then
+    echo "Baseline file not found: ${BASELINE_FILE}" >&2
+    exit 1
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required for benchmarking" >&2
+    exit 1
+fi
+
+if [[ "${CI:-}" != "true" && -f "${ROOT_DIR}/.sdkmanrc" ]]; then
+    SDKMAN_JAVA_VERSION="$(grep '^java=' "${ROOT_DIR}/.sdkmanrc" | head -n 1 | cut -d'=' -f2- | xargs || true)"
+    if [[ -n "${SDKMAN_JAVA_VERSION}" && -d "${HOME}/.sdkman/candidates/java/${SDKMAN_JAVA_VERSION}" ]]; then
+        export JAVA_HOME="${HOME}/.sdkman/candidates/java/${SDKMAN_JAVA_VERSION}"
+        export PATH="${JAVA_HOME}/bin:${PATH}"
+    fi
+fi
+
+NEEDS_BUILD=false
+if [[ ! -f "${LUCLI_JAR}" || ! -x "${LUCLI_BINARY}" ]]; then
+    NEEDS_BUILD=true
+elif ! java -jar "${LUCLI_JAR}" --version >/dev/null 2>&1; then
+    NEEDS_BUILD=true
+fi
+
+if [[ "${NEEDS_BUILD}" == "true" ]]; then
+    echo "ℹ️ LuCLI artifacts missing or not runnable with current Java, building target/lucli.jar and target/lucli..."
+    (
+        cd "${ROOT_DIR}"
+        rm -rf target
+        mvn package -q -Dmaven.test.skip=true -Djreleaser.dry.run=true
+        cat src/bin/lucli.sh target/lucli.jar > target/lucli
+        chmod 755 target/lucli
+    )
+fi
+
+mkdir -p "$(dirname "${OUTPUT_FILE}")"
+
+python3 - "${LUCLI_JAR}" "${RUNS}" "${WARMUP}" "${OUTPUT_FILE}" "${BASELINE_FILE}" "${MAX_REGRESSION_PCT}" <<'PY'
+import datetime
+import json
+import math
+import statistics
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+jar = sys.argv[1]
+runs = int(sys.argv[2])
+warmup = int(sys.argv[3])
+output_file = sys.argv[4]
+baseline_file = sys.argv[5]
+max_regression_raw = sys.argv[6]
+max_regression = float(max_regression_raw) if max_regression_raw else None
+
+benchmarks = [
+    ("startup_version", ["java", "-jar", jar, "--version"]),
+    ("cfml_now", ["java", "-jar", jar, "cfml", "writeOutput(now())"]),
+]
+
+def p95(values):
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    idx = max(0, math.ceil(0.95 * len(ordered)) - 1)
+    return ordered[idx]
+
+def run_benchmark(name, command):
+    for _ in range(warmup):
+        warmup_proc = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        if warmup_proc.returncode != 0:
+            raise RuntimeError(f"Warmup failed for {name} with exit code {warmup_proc.returncode}")
+
+    durations = []
+    for _ in range(runs):
+        started = time.perf_counter()
+        proc = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        if proc.returncode != 0:
+            raise RuntimeError(f"Benchmark run failed for {name} with exit code {proc.returncode}")
+        durations.append(elapsed_ms)
+
+    return {
+        "runs": runs,
+        "warmup_runs": warmup,
+        "mean_ms": round(statistics.mean(durations), 3),
+        "median_ms": round(statistics.median(durations), 3),
+        "p95_ms": round(p95(durations), 3),
+        "min_ms": round(min(durations), 3),
+        "max_ms": round(max(durations), 3),
+        "stddev_ms": round(statistics.pstdev(durations), 3),
+        "samples_ms": [round(v, 3) for v in durations],
+    }
+
+results = {}
+for name, cmd in benchmarks:
+    results[name] = run_benchmark(name, cmd)
+
+payload = {
+    "generated_at_utc": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+    "runs": runs,
+    "warmup_runs": warmup,
+    "results": results,
+}
+
+Path(output_file).write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+print(f"Saved benchmark JSON: {output_file}")
+for name in ["startup_version", "cfml_now"]:
+    metrics = results[name]
+    print(
+        f"{name}: median={metrics['median_ms']}ms, p95={metrics['p95_ms']}ms, "
+        f"mean={metrics['mean_ms']}ms, min={metrics['min_ms']}ms, max={metrics['max_ms']}ms"
+    )
+
+if baseline_file:
+    baseline = json.loads(Path(baseline_file).read_text(encoding="utf-8"))
+    baseline_results = baseline.get("results", {})
+    failing_deltas = []
+
+    print("")
+    print(f"Comparison against baseline: {baseline_file}")
+    for name in ["startup_version", "cfml_now"]:
+        current_median = results[name]["median_ms"]
+        baseline_median = baseline_results.get(name, {}).get("median_ms")
+        if baseline_median is None or baseline_median == 0:
+            print(f"{name}: baseline median missing; skipped")
+            continue
+
+        delta_ms = current_median - baseline_median
+        delta_pct = (delta_ms / baseline_median) * 100.0
+        direction = "faster" if delta_ms < 0 else "slower"
+        print(
+            f"{name}: baseline={baseline_median}ms -> current={current_median}ms "
+            f"({abs(delta_ms):.3f}ms, {abs(delta_pct):.2f}% {direction})"
+        )
+
+        if max_regression is not None and delta_pct > max_regression:
+            failing_deltas.append((name, delta_pct))
+
+    if failing_deltas:
+        labels = ", ".join([f"{name} ({pct:.2f}%)" for name, pct in failing_deltas])
+        raise SystemExit(f"Regression threshold exceeded ({max_regression}%): {labels}")
+PY


### PR DESCRIPTION
## Summary
- add a dedicated GitHub Actions workflow at `.github/workflows/perf-benchmark.yml`
- run startup and `cfml now()` benchmarks via `tests/perf/benchmark-startup.sh`
- publish benchmark results as workflow summary + uploaded JSON artifact
- add a Benchmarks status badge to `README.md`
- document the change in `CHANGELOG.md` and `LEARNINGS.md`

## Validation
- `mvn test`
- `./tests/test-bats.sh`

## Context
- Conversation: https://app.warp.dev/conversation/674f4ccd-4a56-49f5-ab70-7293ed4d1d5d
