### PR TITLE
Follow-up: stabilize BATS runtime performance and defaults

### DIFF
--- a/content/assets/schemas/v1/lucee.schema.json
+++ b/content/assets/schemas/v1/lucee.schema.json
@@ -164,7 +164,7 @@
         },
         "password": {
           "type": "string",
-          "description": "Administrator password. SECURITY WARNING: Using plain text passwords is strongly discouraged. Use environment variable syntax like ${LUCEE_ADMIN_PASSWORD} or ${LUCEE_ADMIN_PASSWORD:-defaultValue} instead to avoid committing secrets to version control.",
+          "description": "Administrator password. SECURITY WARNING: Using plain text passwords is strongly discouraged. Use LuCLI placeholders like #env:LUCEE_ADMIN_PASSWORD# or #secret:admin.password# instead to avoid committing secrets to version control.",
           "default": ""
         }
       }
@@ -250,7 +250,7 @@
     },
     "envVars": {
       "type": "object",
-      "description": "Additional environment variables to inject into the Tomcat process. Keys are environment variable names; values are strings that support `${VAR}` and `${VAR:-default}` substitution. Resolved values are passed to the child Java process via its environment.",
+      "description": "Additional environment variables to inject into the Tomcat process. Keys are environment variable names; values are strings that support #env:VAR# and #env:VAR:-default# substitution (deprecated ${VAR} syntax still works for backward compatibility). Resolved values are passed to the child Java process via its environment.",
       "additionalProperties": {
         "type": "string"
       },

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>org.lucee</groupId>
   <artifactId>lucli</artifactId>
-  <version>0.3.19-SNAPSHOT</version>
+  <version>0.3.21-SNAPSHOT</version>
 
   <name>LuCLI</name>
   <description>A CLI for Lucee</description>
@@ -20,7 +20,7 @@
     <maven.compiler.target>21</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jline.version>3.26.3</jline.version>
-    <lucee.version>7.0.4.18-SNAPSHOT</lucee.version>
+    <lucee.version>7.1.0.197-SNAPSHOT</lucee.version>
     <!-- <lucee.classifier></lucee.classifier> -->
     <lucee.classifier>zero</lucee.classifier>
     

--- a/src/main/java/org/lucee/lucli/config/editor/ConfigEditor.java
+++ b/src/main/java/org/lucee/lucli/config/editor/ConfigEditor.java
@@ -84,8 +84,8 @@ public class ConfigEditor {
             updaters.put("host", () -> config.host = host);
         }
 
-        // version
-        printFieldHelp("version", props);
+        // lucee.version
+        description("Lucee engine version for this server (stored at lucee.version).");
 
         // Show a short suggestion list of known versions (if available)
         List<String> suggestedVersions = null;
@@ -122,7 +122,7 @@ public class ConfigEditor {
                 }
             }
             final String applyVersion = chosenVersion;
-            updaters.put("version", () -> LuceeServerConfig.setLuceeVersion(config, applyVersion));
+            updaters.put("lucee.version", () -> LuceeServerConfig.setLuceeVersion(config, applyVersion));
         }
 
         // port
@@ -425,7 +425,7 @@ public class ConfigEditor {
         String currentPassword = (config.admin != null) ? nullToEmpty(config.admin.password) : "";
         if (currentPassword.isEmpty()) {
             description("Admin password: (not set)");
-        } else if (currentPassword.matches("^\\$\\{.+}$")) {
+        } else if (currentPassword.matches("^(\\$\\{.+\\}|#(?:env|secret):.+#)$")) {
             description("Admin password uses placeholder reference (env var or secret).");
         } else {
             description("Admin password is plain text (consider switching to a placeholder reference).");
@@ -433,8 +433,8 @@ public class ConfigEditor {
 
         System.out.println("Admin password options:");
         description("k) keep current");
-        description("e) use environment variable reference (e.g. ${LUCEE_ADMIN_PASSWORD})");
-        description("s) use secret store placeholder (e.g. ${secret:admin.password})");
+        description("e) use environment variable reference (e.g. #env:LUCEE_ADMIN_PASSWORD#)");
+        description("s) use secret store placeholder (e.g. #secret:admin.password#)");
         description("p) set plain password");
         System.out.print("Choice [k]: ");
         String adminChoice = scanner.nextLine().trim().toLowerCase();
@@ -450,7 +450,7 @@ public class ConfigEditor {
             if (var.isEmpty()) {
                 var = "LUCEE_ADMIN_PASSWORD";
             }
-            newAdminPassword = "${" + var + "}";
+            newAdminPassword = "#env:" + var + "#";
         } else if (adminChoice.equals("s")) {
             newAdminPassword = configureAdminPasswordSecret(scanner, config);
         } else if (adminChoice.equals("p")) {
@@ -802,7 +802,7 @@ public class ConfigEditor {
                 System.out.print("Secret '" + name + "' already exists. Use it for admin password? (Y/n): ");
                 String useExisting = scanner.nextLine().trim().toLowerCase();
                 if (useExisting.isEmpty() || useExisting.equals("y") || useExisting.equals("yes")) {
-                    return "${secret:" + name + "}";
+                    return "#secret:" + name + "#";
                 }
                 System.out.println("Skipping secret-based admin password.");
                 return null;
@@ -829,7 +829,7 @@ public class ConfigEditor {
             String desc = "Lucee admin password for server '" + (config.name != null ? config.name : "<unnamed>") + "'";
             store.put(name, v1, desc);
             System.out.println("Stored secret '" + name + "'.");
-            return "${secret:" + name + "}";
+            return "#secret:" + name + "#";
         } catch (SecretStoreException e) {
             System.out.println("⚠️ Failed to use secret store for admin password: " + e.getMessage());
             return null;

--- a/src/main/java/org/lucee/lucli/server/LuceeServerConfig.java
+++ b/src/main/java/org/lucee/lucli/server/LuceeServerConfig.java
@@ -30,6 +30,7 @@ import com.fasterxml.jackson.core.JsonParser;
  * Handles Lucee server configuration from lucee.json files
  */
 public class LuceeServerConfig {
+    private static final String DEFAULT_APP_VERSION = "1.0.0";
     
     @JsonIgnoreProperties({"dependencies", "devDependencies", "packages", "dependencySettings"})
     public static class ServerConfig {
@@ -49,7 +50,7 @@ public class LuceeServerConfig {
          * to obtain the effective Lucee engine version.
          */
         @Deprecated
-        public String version = "1.0.0";
+        public String version = DEFAULT_APP_VERSION;
 
         /**
          * Lucee engine configuration (version and variant).
@@ -412,6 +413,7 @@ public class LuceeServerConfig {
      *    no {@code lucee} block exists → migrate it and emit a deprecation warning.
      * 3. If both exist, the {@code lucee.version} takes precedence.
      */
+    @SuppressWarnings("deprecation")
     private static void migrateLegacyLuceeVersion(ServerConfig config) {
         if (config.lucee != null && config.lucee.version != null
                 && !config.lucee.version.trim().isEmpty()) {
@@ -427,6 +429,7 @@ public class LuceeServerConfig {
                 config.lucee = new LuceeEngineConfig();
             }
             config.lucee.version = legacyVersion;
+            config.version = DEFAULT_APP_VERSION;
 
             // Migrate runtime.variant into lucee.variant if present
             if (config.runtime != null && config.runtime.variant != null

--- a/src/test/java/org/lucee/lucli/server/LuceeServerConfigTest.java
+++ b/src/test/java/org/lucee/lucli/server/LuceeServerConfigTest.java
@@ -45,6 +45,7 @@ public class LuceeServerConfigTest {
         LuceeServerConfig.ServerConfig config = LuceeServerConfig.createDefaultConfig(tempDir);
         
         assertEquals(tempDir.getFileName().toString(), config.name);
+        assertEquals("1.0.0", config.version);
         // Note: Default version may change - just verify it's set
         assertNotNull(LuceeServerConfig.getLuceeVersion(config));
         // Default port should be in the expected range (8000-8999)
@@ -207,6 +208,7 @@ public class LuceeServerConfigTest {
         assertNotNull(config.lucee, "lucee block should be created during migration");
         assertEquals("6.2.2.91", config.lucee.version);
         assertEquals("6.2.2.91", LuceeServerConfig.getLuceeVersion(config));
+        assertEquals("1.0.0", config.version);
     }
 
     @Test

--- a/tests/bats/02_server_dry_run.bats
+++ b/tests/bats/02_server_dry_run.bats
@@ -4,13 +4,10 @@ load './test_helper.bash'
 
 setup_file() {
     require_lucli_artifacts
-}
-
-setup() {
     setup_lucli_home
 }
 
-teardown() {
+teardown_file() {
     cleanup_lucli_home
 }
 

--- a/tests/bats/06_server_preview_flags.bats
+++ b/tests/bats/06_server_preview_flags.bats
@@ -49,7 +49,11 @@ create_https_preview_project() {
 {
   "name": "https-preview",
   "port": 8080,
-  "version": "6.2.2.91",
+  "version": "1.0.0",
+  "lucee": {
+    "version": "7.0.4.34",
+    "variant": "zero"
+  },
   "https": {
     "enabled": true,
     "port": 8443,

--- a/tests/bats/07_env_merge_extended.bats
+++ b/tests/bats/07_env_merge_extended.bats
@@ -4,13 +4,9 @@ load './test_helper.bash'
 
 setup_file() {
     require_lucli_artifacts
-}
-
-setup() {
     setup_lucli_home
 }
-
-teardown() {
+teardown_file() {
     cleanup_lucli_home
 }
 

--- a/tests/bats/11_cfml_exit_code.bats
+++ b/tests/bats/11_cfml_exit_code.bats
@@ -22,6 +22,12 @@ teardown() {
     assert_output_contains "3"
 }
 
+@test "cfml now() returns a Lucee timestamp literal" {
+    run_lucli cfml 'writeOutput(now())'
+    assert_success
+    assert_output_matches "\\{ts '[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}'\\}"
+}
+
 @test "cfml command exits non-zero when expression throws" {
     # Regression guard: picocli was mapping the catch-block's null return
     # to exit 0, so every CFML failure reported success. Shell pipelines,

--- a/tests/bats/12_perf_smoke.bats
+++ b/tests/bats/12_perf_smoke.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+
+load './test_helper.bash'
+
+setup_file() {
+    require_lucli_artifacts
+}
+
+setup() {
+    setup_lucli_home
+}
+
+teardown() {
+    cleanup_lucli_home
+}
+
+measure_lucli_elapsed_ms() {
+    run python3 - "${LUCLI_JAR}" "$@" <<'PY'
+import subprocess
+import sys
+import time
+
+jar = sys.argv[1]
+args = sys.argv[2:]
+command = ["java", "-jar", jar, *args]
+
+started = time.perf_counter()
+completed = subprocess.run(command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+elapsed_ms = int((time.perf_counter() - started) * 1000)
+print(elapsed_ms)
+sys.exit(completed.returncode)
+PY
+}
+
+@test "perf smoke: --version completes under threshold" {
+    if ! command -v python3 >/dev/null 2>&1; then
+        skip "python3 is required for perf smoke timing"
+    fi
+
+    local threshold_ms="${LUCLI_PERF_SMOKE_VERSION_MS:-15000}"
+    measure_lucli_elapsed_ms --version
+    assert_success
+    assert_output_matches "^[0-9]+$"
+
+    local elapsed_ms="${output}"
+    [ "${elapsed_ms}" -le "${threshold_ms}" ]
+}
+
+@test "perf smoke: cfml now() completes under threshold" {
+    if ! command -v python3 >/dev/null 2>&1; then
+        skip "python3 is required for perf smoke timing"
+    fi
+
+    local threshold_ms="${LUCLI_PERF_SMOKE_CFML_NOW_MS:-20000}"
+    measure_lucli_elapsed_ms cfml 'writeOutput(now())'
+    assert_success
+    assert_output_matches "^[0-9]+$"
+
+    local elapsed_ms="${output}"
+    [ "${elapsed_ms}" -le "${threshold_ms}" ]
+}

--- a/tests/bats/test_helper.bash
+++ b/tests/bats/test_helper.bash
@@ -29,6 +29,9 @@ setup_lucli_home() {
     local tmp_base
     tmp_base="${BATS_TEST_TMPDIR:-${BATS_FILE_TMPDIR:-${TMPDIR:-/tmp}}}"
     LUCLI_HOME="$(mktemp -d "${tmp_base%/}/lucli-home.XXXXXX")"
+    if [[ -n "${LUCLI_BATS_EXPRESS_CACHE_DIR:-}" && -d "${LUCLI_BATS_EXPRESS_CACHE_DIR}" ]]; then
+        ln -s "${LUCLI_BATS_EXPRESS_CACHE_DIR}" "${LUCLI_HOME}/express"
+    fi
 }
 
 cleanup_lucli_home() {
@@ -49,6 +52,28 @@ run_lucli_in_dir() {
     local workdir="$1"
     shift
     run bash -c 'cd "$1" && shift && jar="$1" && shift && java -jar "$jar" "$@"' _ "${workdir}" "${LUCLI_JAR}" "$@"
+}
+
+prewarm_test_lucee_runtime() {
+    local tmp_base
+    local project_dir
+    tmp_base="${BATS_TEST_TMPDIR:-${BATS_FILE_TMPDIR:-${TMPDIR:-/tmp}}}"
+    project_dir="$(mktemp -d "${tmp_base%/}/prewarm-project.XXXXXX")"
+
+    cat > "${project_dir}/lucee.json" << 'EOF'
+{
+  "name": "bats-runtime-prewarm",
+  "version": "1.0.0",
+  "lucee": {
+    "version": "7.0.4.34",
+    "variant": "zero"
+  },
+  "openBrowser": false
+}
+EOF
+
+    java -jar "${LUCLI_JAR}" server start --prewarm "${project_dir}" >/dev/null 2>&1
+    rm -rf "${project_dir}"
 }
 
 stop_all_servers_if_possible() {
@@ -126,7 +151,11 @@ create_env_test_project() {
 {
   "name": "env-test",
   "port": 8080,
-  "version": "6.2.2.91",
+  "version": "1.0.0",
+  "lucee": {
+    "version": "7.0.4.34",
+    "variant": "zero"
+  },
   "jvm": {
     "maxMemory": "512m",
     "minMemory": "128m"

--- a/tests/test-bats.sh
+++ b/tests/test-bats.sh
@@ -23,6 +23,8 @@ else
     exit 1
 fi
 
+export BATS_TEST_TIMEOUT="${BATS_TEST_TIMEOUT:-10}"
+
 if [[ "${CI:-}" == "true" && -z "${TERM:-}" ]]; then
     export TERM="dumb"
 fi
@@ -48,6 +50,26 @@ if [[ "${NEEDS_BUILD}" == "true" ]]; then
         chmod 755 target/lucli
     )
 fi
+
+
+BATS_CACHE_HOME="${BATS_CACHE_HOME:-${TMPDIR:-/tmp}/lucli-bats-cache}"
+mkdir -p "${BATS_CACHE_HOME}"
+PREWARM_PROJECT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/lucli-prewarm.XXXXXX")"
+cat > "${PREWARM_PROJECT_DIR}/lucee.json" << 'EOF'
+{
+  "name": "bats-runtime-cache",
+  "version": "1.0.0",
+  "lucee": {
+    "version": "7.0.4.34",
+    "variant": "zero"
+  },
+  "openBrowser": false
+}
+EOF
+if LUCLI_HOME="${BATS_CACHE_HOME}" java -jar "${LUCLI_JAR}" server start --prewarm "${PREWARM_PROJECT_DIR}" >/dev/null 2>&1; then
+    export LUCLI_BATS_EXPRESS_CACHE_DIR="${BATS_CACHE_HOME}/express"
+fi
+rm -rf "${PREWARM_PROJECT_DIR}"
 
 if [[ -n "${BATS_JUNIT_XML_OUTPUT}" ]]; then
     BATS_REPORT_DIR="$(mktemp -d "${TMPDIR:-/tmp}/bats-report.XXXXXX")"


### PR DESCRIPTION
## Summary
- add `tests/bats/12_perf_smoke.bats` for startup/`cfml now()` perf smoke checks
- add `cfml now()` timestamp assertion to `tests/bats/11_cfml_exit_code.bats`
- harden BATS runtime setup in `tests/test-bats.sh` and `tests/bats/test_helper.bash` with timeout and shared runtime cache wiring
- update server dry-run/env-merge BATS fixtures to use Lucee `7.0.4.34` with `variant: zero`
- align Lucee defaults/editing/schema updates in:
  - `src/main/java/org/lucee/lucli/server/LuceeServerConfig.java`
  - `src/main/java/org/lucee/lucli/config/editor/ConfigEditor.java`
  - `content/assets/schemas/v1/lucee.schema.json`
  - `pom.xml`
  - `src/test/java/org/lucee/lucli/server/LuceeServerConfigTest.java`

## Validation
- `mvn test`
- `./tests/test-bats.sh`

## Notes
This PR is stacked on top of #76.
