### PR TITLE
Docs: add trunk-based release workflow and CLA/DCO requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,6 +49,55 @@ mvn clean package -Pbinary
 - Include example commands/output when relevant.
 - Mention any known limitations or follow-up work.
 - Keep PR scope narrow to simplify review.
+- All external contributions must pass the repository's contribution agreement check (CLA or DCO) before merge.
+
+## Branching and Release Workflow (Trunk-Based)
+LuCLI uses a trunk-based workflow instead of full GitFlow.
+
+- `main` is the trunk and should remain releasable.
+- Use short-lived branches for work (for example: `feat/...`, `fix/...`, `docs/...`).
+- Open PRs into `main` and merge frequently in small increments.
+- Use release branches only when stabilizing a release (for example: `release/x.y`).
+- Apply urgent fixes from the release branch/tag, publish the patch release, then merge those fixes back to `main`.
+
+Release flow summary:
+1. Develop on short-lived branches and merge to `main`.
+2. Optionally cut `release/x.y` for stabilization.
+3. Remove `-SNAPSHOT` to publish a release version.
+4. Immediately bump to the next `-SNAPSHOT` after release.
+
+## CLA / DCO Requirement
+Every PR must satisfy the configured contribution agreement gate:
+- **CLA mode:** sign the CLA when the bot requests it in the PR.
+- **DCO mode:** sign commits with `Signed-off-by` (for example, `git commit -s`).
+
+Maintainers enforce this with required status checks in branch protection.
+
+## Versioning for Contributors
+LuCLI uses `MAJOR.MINOR.PATCH[-SNAPSHOT]` in `pom.xml`.
+
+### Which version to bump
+- **Patch** (`x.y.Z`): bug fixes, docs, CI/tooling changes, and low-risk improvements.
+- **Minor** (`x.Y.0`): new features or user-visible behavior additions.
+- **Major** (`X.0.0`): breaking changes (removed/renamed commands, incompatible config/output changes, or runtime requirement changes).
+
+When in doubt:
+- If users/scripts should not need changes, use **patch**.
+- If behavior/features expand in user-facing ways, use **minor**.
+- If users/scripts must change, use **major**.
+
+### Snapshot and release flow
+- Keep development on `-SNAPSHOT` versions.
+- Release by removing `-SNAPSHOT`, committing, and pushing.
+- Immediately bump to the next `-SNAPSHOT` after a release.
+
+Use the helper script:
+```bash
+./scripts/release.sh status
+./scripts/release.sh bump patch|minor|major
+./scripts/release.sh release
+./scripts/release.sh next-snapshot
+```
 
 ## Release and Process References
 - Release details: [RELEASE_PROCESS.md](RELEASE_PROCESS.md)

--- a/RELEASE_PROCESS.md
+++ b/RELEASE_PROCESS.md
@@ -1,0 +1,58 @@
+# LuCLI Release Process
+This document describes how releases are created and how contributors should apply version bumps.
+
+## Overview
+LuCLI uses automated releases driven by the version in `pom.xml`:
+- versions ending in `-SNAPSHOT` are development versions
+- non-snapshot versions are release versions
+- releases are created by GitHub Actions when a new release version is pushed
+
+## Versioning Policy
+LuCLI uses `MAJOR.MINOR.PATCH[-SNAPSHOT]`.
+
+### Which version to bump
+- **Patch** (`x.y.Z`): bug fixes, docs, CI/tooling changes, and low-risk improvements.
+- **Minor** (`x.Y.0`): new features or user-visible behavior additions.
+- **Major** (`X.0.0`): breaking changes (removed/renamed commands, incompatible config/output changes, or runtime requirement changes).
+
+When in doubt:
+- if users/scripts should not need changes, use **patch**
+- if behavior/features expand in user-facing ways, use **minor**
+- if users/scripts must change, use **major**
+
+## Snapshot and Release Flow
+1. Keep development on a `-SNAPSHOT` version.
+2. Prepare a release by removing `-SNAPSHOT`.
+3. Commit and push the version change.
+4. After release completes, bump to the next `-SNAPSHOT`.
+
+Using the helper script:
+```bash
+./scripts/release.sh status
+./scripts/release.sh bump patch|minor|major
+./scripts/release.sh release
+./scripts/release.sh next-snapshot
+```
+
+## Typical Release Steps
+```bash
+# Check current status
+./scripts/release.sh status
+
+# Prepare release (remove -SNAPSHOT)
+./scripts/release.sh release
+git add pom.xml
+git commit -m "Prepare release X.Y.Z"
+git push
+
+# After release automation completes, move to next dev version
+./scripts/release.sh next-snapshot
+git add pom.xml
+git commit -m "Prepare next development iteration"
+git push
+```
+
+## Troubleshooting
+- No release created: confirm `pom.xml` version does not end with `-SNAPSHOT`.
+- Duplicate version: confirm a tag/release for that version does not already exist.
+- Build failure: run `mvn test` locally and check workflow logs.


### PR DESCRIPTION
## Summary
- document trunk-based branching and release flow in `CONTRIBUTING.md`
- add explicit contributor agreement requirement (CLA or DCO) for PRs
- add `RELEASE_PROCESS.md` with aligned versioning and snapshot/release workflow guidance

## Notes
- this PR includes documentation-only changes
