### PR TITLE
Fix Windows EXE emoji fallback behavior and script env propagation reliability

### DIFF
--- a/src/main/java/org/lucee/lucli/CommandProcessor.java
+++ b/src/main/java/org/lucee/lucli/CommandProcessor.java
@@ -135,7 +135,8 @@ public class CommandProcessor {
                     result = cflintCommand(commandLine);
                     break;
                 default:
-                    result = "❌ Unknown command: " + command + "\n💡 Type 'help' for available commands.";
+                    result = WindowsSupport.getEmoji("❌", "[ERROR]") + " Unknown command: " + command
+                           + "\n" + WindowsSupport.getEmoji("💡", "[TIP]") + " Type 'help' for available commands.";
             }
             Timer.stop(command + " command");
             Timer.stop("Command Execution");

--- a/src/main/java/org/lucee/lucli/EmojiSupport.java
+++ b/src/main/java/org/lucee/lucli/EmojiSupport.java
@@ -1,6 +1,9 @@
 package org.lucee.lucli;
 
 import java.util.LinkedHashMap;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -13,9 +16,11 @@ import java.util.Map;
 public class EmojiSupport {
     
     private static boolean enabled = true;
+    private static final String GENERIC_EMOJI_FALLBACK = "[EMOJI]";
     
     // Emoji to text fallback mappings (order matters - longer sequences first)
     private static final Map<String, String> EMOJI_FALLBACKS = new LinkedHashMap<>();
+    private static final List<String> SORTED_FALLBACK_KEYS = new ArrayList<>();
     
     static {
         // Multi-character emojis first (ZWJ sequences, etc.)
@@ -99,6 +104,7 @@ public class EmojiSupport {
         EMOJI_FALLBACKS.put("⚡", "[ZAP]");
         EMOJI_FALLBACKS.put("✨", "*");
         EMOJI_FALLBACKS.put("🔥", "[FIRE]");
+        EMOJI_FALLBACKS.put("🌈", "[PROMPT]");
         EMOJI_FALLBACKS.put("💧", "[DROP]");
         EMOJI_FALLBACKS.put("🍃", "[LEAF]");
         EMOJI_FALLBACKS.put("🌳", "[TREE]");
@@ -171,6 +177,7 @@ public class EmojiSupport {
         EMOJI_FALLBACKS.put("🎭", "[MASK]");
         EMOJI_FALLBACKS.put("🛡️", "[SHIELD]");
         EMOJI_FALLBACKS.put("🔋", "[BAT]");
+        rebuildSortedFallbackKeys();
     }
     
     /**
@@ -194,17 +201,29 @@ public class EmojiSupport {
         if (text == null || text.isEmpty() || enabled) {
             return text;
         }
-        
-        String result = text;
-        for (Map.Entry<String, String> entry : EMOJI_FALLBACKS.entrySet()) {
-            result = result.replace(entry.getKey(), entry.getValue());
+
+        StringBuilder out = new StringBuilder(text.length());
+        int index = 0;
+        while (index < text.length()) {
+            String explicitMatch = findExplicitFallbackMatch(text, index);
+            if (explicitMatch != null) {
+                out.append(EMOJI_FALLBACKS.get(explicitMatch));
+                index += explicitMatch.length();
+                continue;
+            }
+
+            int emojiEnd = findGenericEmojiSequenceEnd(text, index);
+            if (emojiEnd > index) {
+                out.append(GENERIC_EMOJI_FALLBACK);
+                index = emojiEnd;
+                continue;
+            }
+
+            int cp = text.codePointAt(index);
+            out.appendCodePoint(cp);
+            index += Character.charCount(cp);
         }
-        
-        // Clean up variation selectors and zero-width joiners that might be left over
-        result = result.replaceAll("[\uFE00-\uFE0F]", "");  // Variation selectors
-        result = result.replace("\u200D", "");              // Zero-width joiner
-        
-        return result;
+        return out.toString();
     }
     
     /**
@@ -219,5 +238,155 @@ public class EmojiSupport {
      */
     public static void addFallback(String emoji, String fallback) {
         EMOJI_FALLBACKS.put(emoji, fallback);
+        rebuildSortedFallbackKeys();
+    }
+
+    private static void rebuildSortedFallbackKeys() {
+        SORTED_FALLBACK_KEYS.clear();
+        SORTED_FALLBACK_KEYS.addAll(EMOJI_FALLBACKS.keySet());
+        SORTED_FALLBACK_KEYS.sort(Comparator.comparingInt(String::length).reversed());
+    }
+
+    private static String findExplicitFallbackMatch(String text, int index) {
+        for (String key : SORTED_FALLBACK_KEYS) {
+            if (text.startsWith(key, index)) {
+                return key;
+            }
+        }
+        return null;
+    }
+
+    private static int findGenericEmojiSequenceEnd(String text, int index) {
+        int cp = text.codePointAt(index);
+
+        if (isKeycapBase(cp)) {
+            int next = index + Character.charCount(cp);
+            if (next < text.length()) {
+                int nextCp = text.codePointAt(next);
+                if (isVariationSelector(nextCp)) {
+                    next += Character.charCount(nextCp);
+                }
+            }
+            if (next < text.length()) {
+                int nextCp = text.codePointAt(next);
+                if (isCombiningEnclosingKeycap(nextCp)) {
+                    return next + Character.charCount(nextCp);
+                }
+            }
+            return -1;
+        }
+
+        if (isRegionalIndicator(cp)) {
+            int next = index + Character.charCount(cp);
+            if (next < text.length()) {
+                int nextCp = text.codePointAt(next);
+                if (isRegionalIndicator(nextCp)) {
+                    return next + Character.charCount(nextCp);
+                }
+            }
+            return -1;
+        }
+
+        if (!isLikelyEmojiBase(cp)) {
+            return -1;
+        }
+
+        int current = index + Character.charCount(cp);
+
+        if (current < text.length()) {
+            int maybeVs = text.codePointAt(current);
+            if (isVariationSelector(maybeVs)) {
+                current += Character.charCount(maybeVs);
+            }
+        }
+
+        if (current < text.length()) {
+            int maybeModifier = text.codePointAt(current);
+            if (isEmojiModifier(maybeModifier)) {
+                current += Character.charCount(maybeModifier);
+            }
+        }
+
+        if (cp == 0x1F3F4) {
+            int tagCursor = current;
+            boolean sawTag = false;
+            while (tagCursor < text.length()) {
+                int tagCp = text.codePointAt(tagCursor);
+                if (isTagCharacter(tagCp)) {
+                    sawTag = true;
+                    tagCursor += Character.charCount(tagCp);
+                    continue;
+                }
+                if (tagCp == 0xE007F && sawTag) {
+                    current = tagCursor + Character.charCount(tagCp);
+                }
+                break;
+            }
+        }
+
+        while (current < text.length()) {
+            int zwj = text.codePointAt(current);
+            if (!isZeroWidthJoiner(zwj)) {
+                break;
+            }
+            int nextBaseIndex = current + Character.charCount(zwj);
+            if (nextBaseIndex >= text.length()) {
+                break;
+            }
+            int nextBase = text.codePointAt(nextBaseIndex);
+            if (!isLikelyEmojiBase(nextBase)) {
+                break;
+            }
+
+            current = nextBaseIndex + Character.charCount(nextBase);
+            if (current < text.length()) {
+                int maybeVs = text.codePointAt(current);
+                if (isVariationSelector(maybeVs)) {
+                    current += Character.charCount(maybeVs);
+                }
+            }
+            if (current < text.length()) {
+                int maybeModifier = text.codePointAt(current);
+                if (isEmojiModifier(maybeModifier)) {
+                    current += Character.charCount(maybeModifier);
+                }
+            }
+        }
+
+        return current;
+    }
+
+    private static boolean isLikelyEmojiBase(int cp) {
+        return (cp >= 0x1F000 && cp <= 0x1FAFF)
+            || (cp >= 0x2600 && cp <= 0x27BF)
+            || (cp >= 0x2300 && cp <= 0x23FF);
+    }
+
+    private static boolean isRegionalIndicator(int cp) {
+        return cp >= 0x1F1E6 && cp <= 0x1F1FF;
+    }
+
+    private static boolean isEmojiModifier(int cp) {
+        return cp >= 0x1F3FB && cp <= 0x1F3FF;
+    }
+
+    private static boolean isVariationSelector(int cp) {
+        return cp == 0xFE0F || cp == 0xFE0E;
+    }
+
+    private static boolean isZeroWidthJoiner(int cp) {
+        return cp == 0x200D;
+    }
+
+    private static boolean isKeycapBase(int cp) {
+        return (cp >= '0' && cp <= '9') || cp == '#' || cp == '*';
+    }
+
+    private static boolean isCombiningEnclosingKeycap(int cp) {
+        return cp == 0x20E3;
+    }
+
+    private static boolean isTagCharacter(int cp) {
+        return cp >= 0xE0020 && cp <= 0xE007E;
     }
 }

--- a/src/main/java/org/lucee/lucli/ExternalCommandProcessor.java
+++ b/src/main/java/org/lucee/lucli/ExternalCommandProcessor.java
@@ -161,7 +161,7 @@ public class ExternalCommandProcessor {
             if (commandParts != null
                 && commandParts.length > 0
                 && "env".equalsIgnoreCase(commandParts[0])
-                && System.getProperty("os.name").toLowerCase().contains("windows")) {
+                && System.getProperty("os.name").toLowerCase(java.util.Locale.ROOT).contains("windows")) {
                 normalizedCommandParts = new String[] { "cmd", "/c", "set" };
             }
 

--- a/src/main/java/org/lucee/lucli/ExternalCommandProcessor.java
+++ b/src/main/java/org/lucee/lucli/ExternalCommandProcessor.java
@@ -66,7 +66,7 @@ public class ExternalCommandProcessor {
         
         // System commands
         knownExternalCommands.addAll(Arrays.asList(
-            "ps", "top", "htop", "kill", "killall", "which", "whereis"
+            "ps", "top", "htop", "kill", "killall", "which", "whereis", "env"
         ));
     }
     
@@ -157,7 +157,15 @@ public class ExternalCommandProcessor {
      */
     private String executeExternalCommand(String[] commandParts) {
         try {
-            ProcessBuilder pb = new ProcessBuilder(commandParts);
+            String[] normalizedCommandParts = commandParts;
+            if (commandParts != null
+                && commandParts.length > 0
+                && "env".equalsIgnoreCase(commandParts[0])
+                && System.getProperty("os.name").toLowerCase().contains("windows")) {
+                normalizedCommandParts = new String[] { "cmd", "/c", "set" };
+            }
+
+            ProcessBuilder pb = new ProcessBuilder(normalizedCommandParts);
             pb.directory(fileSystemProcessor.getFileSystemState().getCurrentWorkingDirectory().toFile());
             pb.redirectErrorStream(true); // Merge stderr with stdout
             if (LuCLI.scriptEnvironment != null && !LuCLI.scriptEnvironment.isEmpty()) {
@@ -181,14 +189,14 @@ public class ExternalCommandProcessor {
             
             if (!finished) {
                 process.destroyForcibly();
-                return "⚠️ Command timed out after 30 seconds: " + String.join(" ", commandParts);
+                return "⚠️ Command timed out after 30 seconds: " + String.join(" ", normalizedCommandParts);
             }
             
             int exitCode = process.exitValue();
             String result = output.toString().trim();
             
             if (exitCode != 0 && result.isEmpty()) {
-                return "❌ Command failed with exit code " + exitCode + ": " + String.join(" ", commandParts);
+                return "❌ Command failed with exit code " + exitCode + ": " + String.join(" ", normalizedCommandParts);
             }
             
             return result;

--- a/src/main/java/org/lucee/lucli/Settings.java
+++ b/src/main/java/org/lucee/lucli/Settings.java
@@ -258,10 +258,11 @@ public class Settings {
     }
     
     /**
-     * Check if emojis are enabled
+     * Check if emojis are enabled and supported by the current platform.
+     * Returns the effective enabled state: user preference AND platform capability.
      */
     public boolean showEmojis() {
-        return getBoolean("showEmojis", WindowsSupport.supportsEmojis());
+        return getBoolean("showEmojis", WindowsSupport.supportsEmojis()) && WindowsSupport.supportsEmojis();
     }
     
     /**

--- a/src/main/java/org/lucee/lucli/Settings.java
+++ b/src/main/java/org/lucee/lucli/Settings.java
@@ -74,10 +74,8 @@ public class Settings {
      * Sync the showEmojis setting to EmojiSupport global state
      */
     private void syncEmojiPreference() {
-        JsonNode emojiNode = settings.path("showEmojis");
-        if (!emojiNode.isMissingNode()) {
-            EmojiSupport.setEnabled(emojiNode.asBoolean());
-        }
+        boolean userEnabled = showEmojis();
+        EmojiSupport.setEnabled(userEnabled && WindowsSupport.supportsEmojis());
     }
     
     /**
@@ -263,7 +261,7 @@ public class Settings {
      * Check if emojis are enabled
      */
     public boolean showEmojis() {
-        return getBoolean("showEmojis", true);
+        return getBoolean("showEmojis", WindowsSupport.supportsEmojis());
     }
     
     /**
@@ -280,7 +278,7 @@ public class Settings {
     public void setShowEmojis(boolean showEmojis) {
         setBoolean("showEmojis", showEmojis);
         // Sync to global state
-        EmojiSupport.setEnabled(showEmojis);
+        EmojiSupport.setEnabled(showEmojis && WindowsSupport.supportsEmojis());
     }
     
     /**

--- a/src/main/java/org/lucee/lucli/Terminal.java
+++ b/src/main/java/org/lucee/lucli/Terminal.java
@@ -186,7 +186,7 @@ public class Terminal {
                 // Dispatch command
                 String result = dispatchCommand(trimmed);
                 if (result != null && !result.isEmpty()) {
-                    terminal.writer().println(result);
+                    terminal.writer().println(EmojiSupport.process(result));
                 }
                 
                 terminal.writer().flush();

--- a/src/main/java/org/lucee/lucli/WindowsSupport.java
+++ b/src/main/java/org/lucee/lucli/WindowsSupport.java
@@ -16,8 +16,8 @@ public class WindowsSupport {
      */
     public static boolean supportsEmojis() {
         if (IS_WINDOWS) {
-            String charset = Charset.defaultCharset().name();
-            if (charset == null || !charset.toLowerCase().contains("utf-8")) {
+            String normalizedCharset = Charset.defaultCharset().name().replace("-", "").toLowerCase(java.util.Locale.ROOT);
+            if (!"utf8".equals(normalizedCharset)) {
                 return false;
             }
         }

--- a/src/main/java/org/lucee/lucli/WindowsSupport.java
+++ b/src/main/java/org/lucee/lucli/WindowsSupport.java
@@ -1,4 +1,5 @@
 package org.lucee.lucli;
+import java.nio.charset.Charset;
 
 /**
  * Utility class to handle Windows-specific terminal and display compatibility issues
@@ -14,6 +15,12 @@ public class WindowsSupport {
      * Can be used to auto-disable emojis on Windows: EmojiSupport.setEnabled(supportsEmojis())
      */
     public static boolean supportsEmojis() {
+        if (IS_WINDOWS) {
+            String charset = Charset.defaultCharset().name();
+            if (charset == null || !charset.toLowerCase().contains("utf-8")) {
+                return false;
+            }
+        }
         // Windows Terminal and newer PowerShell versions support emojis
         if (IS_WINDOWS_TERMINAL) {
             return true;

--- a/src/test/java/org/lucee/lucli/EmojiSupportTest.java
+++ b/src/test/java/org/lucee/lucli/EmojiSupportTest.java
@@ -1,0 +1,64 @@
+package org.lucee.lucli;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class EmojiSupportTest {
+
+    @AfterEach
+    void restoreEmojiMode() {
+        EmojiSupport.setEnabled(true);
+    }
+
+    @Test
+    void explicitFallbackMapping_shouldApplyFirst() {
+        EmojiSupport.setEnabled(false);
+        String result = EmojiSupport.process("❌ Unknown command");
+        assertEquals("[ERROR] Unknown command", result);
+    }
+
+    @Test
+    void genericUnknownEmoji_shouldFallbackToGenericToken() {
+        EmojiSupport.setEnabled(false);
+        String result = EmojiSupport.process("Status: 🫨");
+        assertEquals("Status: [EMOJI]", result);
+    }
+
+    @Test
+    void zwjSequenceWithoutExplicitMapping_shouldFallbackToSingleGenericToken() {
+        EmojiSupport.setEnabled(false);
+        String result = EmojiSupport.process("Astronaut: 🧑‍🚀 ready");
+        assertEquals("Astronaut: [EMOJI] ready", result);
+    }
+
+    @Test
+    void keycapSequenceWithoutExplicitMapping_shouldFallbackToGenericToken() {
+        EmojiSupport.setEnabled(false);
+        String result = EmojiSupport.process("Press 1️⃣ now");
+        assertEquals("Press [EMOJI] now", result);
+    }
+
+    @Test
+    void nonEmojiCharacters_shouldRemainUnchanged() {
+        EmojiSupport.setEnabled(false);
+        String result = EmojiSupport.process("abc 123 _-+");
+        assertEquals("abc 123 _-+", result);
+    }
+
+    @Test
+    void explicitArrowFallback_shouldStillWork() {
+        EmojiSupport.setEnabled(false);
+        String result = EmojiSupport.process("Path ➤ next");
+        assertEquals("Path > next", result);
+    }
+
+    @Test
+    void regionalFlagPair_shouldUseGenericFallback() {
+        EmojiSupport.setEnabled(false);
+        String result = EmojiSupport.process("Flag: 🇺🇸");
+        assertTrue(result.equals("Flag: [EMOJI]"));
+    }
+}

--- a/src/test/java/org/lucee/lucli/LucliScriptSetEnvPropagationTest.java
+++ b/src/test/java/org/lucee/lucli/LucliScriptSetEnvPropagationTest.java
@@ -45,17 +45,17 @@ class LucliScriptSetEnvPropagationTest {
     void lucliSetValueIsVisibleToRunCfsThroughEnvMap() throws Exception {
         Path cfsFile = tempDir.resolve("print_env.cfs");
         Path lucliFile = tempDir.resolve("script.lucli");
-        String expected = "https://example.invalid/webtrigger";
+        String expected = "https://example.invalid/test-value";
 
         Files.writeString(
             cfsFile,
-            "writeOutput(structKeyExists(__env, \"FORGE_WEBTRIGGER_URL\") ? __env[\"FORGE_WEBTRIGGER_URL\"] : \"missing\");",
+            "writeOutput(structKeyExists(__env, \\\"LUCLI_TEST_ENV_URL\\\") ? __env[\\\"LUCLI_TEST_ENV_URL\\\"] : \\\"missing\\\");",
             StandardCharsets.UTF_8
         );
         Files.write(
             lucliFile,
             List.of(
-                "set FORGE_WEBTRIGGER_URL=\"" + expected + "\"",
+                "set LUCLI_TEST_ENV_URL=\\\"" + expected + "\\\"",
                 "run " + cfsFile.toAbsolutePath()
             ),
             StandardCharsets.UTF_8
@@ -72,19 +72,19 @@ class LucliScriptSetEnvPropagationTest {
         }
 
         String output = captured.toString(StandardCharsets.UTF_8);
-        assertTrue(output.contains(expected), "Expected .cfs output to include FORGE_WEBTRIGGER_URL from .lucli set");
+        assertTrue(output.contains(expected), "Expected .cfs output to include LUCLI_TEST_ENV_URL from .lucli set");
     }
 
     @Test
     void lucliSetValueIsInheritedByExternalCommands() throws Exception {
         Path lucliFile = tempDir.resolve("script_external.lucli");
         Path outputFile = tempDir.resolve("external_env.txt");
-        String expected = "FORGE_WEBTRIGGER_URL=from-lucli-set";
+        String expected = "LUCLI_TEST_ENV_URL=from-lucli-set";
 
         Files.write(
             lucliFile,
             List.of(
-                "set FORGE_WEBTRIGGER_URL=from-lucli-set",
+                "set LUCLI_TEST_ENV_URL=from-lucli-set",
                 "env > " + outputFile.toAbsolutePath()
             ),
             StandardCharsets.UTF_8
@@ -94,7 +94,7 @@ class LucliScriptSetEnvPropagationTest {
         assertEquals(0, exit);
 
         String envOutput = Files.readString(outputFile, StandardCharsets.UTF_8);
-        assertTrue(envOutput.contains(expected), "Expected external command environment to include FORGE_WEBTRIGGER_URL");
+        assertTrue(envOutput.contains(expected), "Expected external command environment to include LUCLI_TEST_ENV_URL");
     }
 
     @Test

--- a/src/test/java/org/lucee/lucli/SettingsTest.java
+++ b/src/test/java/org/lucee/lucli/SettingsTest.java
@@ -203,7 +203,7 @@ class SettingsTest {
     void testSetShowEmojis() {
         Settings settings = new Settings();
         settings.setShowEmojis(true);
-        assertTrue(settings.showEmojis());
+        assertEquals(WindowsSupport.supportsEmojis(), settings.showEmojis());
         
         settings.setShowEmojis(false);
         assertFalse(settings.showEmojis());


### PR DESCRIPTION
## Summary
This PR fixes Windows EXE output mojibake behavior and hardens .lucli script env propagation behavior/tests.

## What changed
- Added robust emoji fallback processing in EmojiSupport:
  - explicit longest-match mappings first
  - generic fallback for unmapped emoji sequences ([EMOJI])
  - support for keycap, regional-flag, VS/modifier, and ZWJ sequences
- Updated terminal output paths to consistently apply fallback processing for command results.
- Updated unknown-command rendering to use fallback-aware symbols.
- Hardened Windows emoji support detection (WindowsSupport) to disable emoji output on non-UTF-8 charset environments.
- Made external nv command handling cross-platform by mapping nv to cmd /c set on Windows.
- Replaced Forge-specific env var test names with neutral LUCLI_TEST_ENV_URL in LucliScriptSetEnvPropagationTest.
- Added focused unit coverage in new EmojiSupportTest.

## Validation
- mvn -Dtest=LucliScriptSetEnvPropagationTest test
- mvn -Dtest=EmojiSupportTest,StringOutputTest,CommandProcessorTest,SettingsTest test
- mvn -Dtest=EmojiSupportTest test
- mvn clean package -Pwindows-exe -DskipTests

## Tracking
- Closes #94
- Conversation: https://app.warp.dev/conversation/6f41ff09-2f1d-4940-bbe0-496074d8c5e2

Co-Authored-By: Oz <oz-agent@warp.dev>