### PR TITLE
test: add regression BATS coverage for confirmed issue fixes

### DIFF
--- a/content/changelog.md
+++ b/content/changelog.md
@@ -1,0 +1,61 @@
+---
+title: Changelog
+subtitle: Release notes and notable updates for LuCLI
+layout: page
+draft: false
+---
+
+This page highlights recent LuCLI changes.
+
+For the complete release history, see:
+
+- [Full `CHANGELOG.md` on GitHub](https://github.com/cybersonic/LuCLI/blob/main/CHANGELOG.md)
+- [GitHub Releases](https://github.com/cybersonic/LuCLI/releases)
+
+## Unreleased
+
+Recent work currently in progress includes:
+
+- Launch4j-based `lucli.exe` packaging for Windows releases.
+- Better environment/config merge behavior (including `configurationFile` layering).
+- Runtime extension activation fixes for environment-specific dependency toggles.
+- MCP improvements for tool schema discovery and cleaner tool descriptions.
+- Profile-aware module and alias-binary command behavior fixes.
+
+## Recent Releases
+
+### 0.3.17
+
+- Added dependency examples docs and improved dry-run preview controls.
+- Added Java 21 runtime checks in wrapper scripts.
+- Added extension dependency `enabled` toggles and prewarm support.
+- Fixed static file passthrough behavior in default URL rewrite config.
+- Added whitelabeling support for branded LuCLI distributions.
+
+### 0.3.3
+
+- Expanded BATS coverage and migration from legacy shell tests.
+- Added script argument variables (`ARGS`, `ARGV`, `__namedArguments`).
+- Added `lucli ai prompt --estimate` rough cost estimation mode.
+- Added SpotBugs integration and testing/QA documentation.
+- Improved server lifecycle resolution and ambiguity handling for multi-server projects.
+
+### 0.2.23
+
+- Added cross-platform bootstrap installers (`install.sh` and `install.ps1`).
+- Added `.lucli` script output redirection (`>` and `>>`).
+- Added per-module MCP server mode via `lucli mcp <module>`.
+- Added interactive and guided `lucli ai config` workflows.
+- Added system backup command group (`create`, `list`, `verify`, `prune`, `restore`).
+
+### 0.2.1
+
+- Migrated URL rewriting to Tomcat `RewriteValve` (`rewrite.config`).
+- Added `#env:VAR#` syntax and protected substitution zones in `lucee.json`.
+- Added pluggable runtime providers (Lucee Express, vendor Tomcat, Docker, Jetty).
+- Added `--config` support for `server stop` and `server restart`.
+- Added `source` directive for `.lucli` scripts and `--envfile` support.
+
+## Looking for older entries?
+
+The full, canonical changelog is maintained in [`CHANGELOG.md`](https://github.com/cybersonic/LuCLI/blob/main/CHANGELOG.md) and includes every historical release.

--- a/content/docs/index.md
+++ b/content/docs/index.md
@@ -83,5 +83,6 @@ If you already know what you’re looking for:
 
 - [Command Reference](reference-and-examples/command-reference/)
 - [Contributing to Documentation](reference-and-examples/contributing-to-documentation/)
+- [Site Changelog](/changelog)
 
 You can always return to this page from the "Docs" home link in the navigation, and use the left sidebar to jump directly to any topic.

--- a/content/layouts/partials/nav.cfm
+++ b/content/layouts/partials/nav.cfm
@@ -13,6 +13,7 @@
             <a href="/#getting-started" class="nav-link">Get started</a> -->
         <a href="/download" class="nav-link">Download</a>
         <a href="/docs/index.html" class="nav-link">Documentation</a>
+        <a href="/changelog" class="nav-link">Changelog</a>
         <a href="/posts/" class="nav-link">Blog</a>
         <a href="/about" class="nav-link">About</a>
         <a

--- a/tests/bats/14_confirmed_issue_regressions.bats
+++ b/tests/bats/14_confirmed_issue_regressions.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+load './test_helper.bash'
+
+setup_file() {
+    require_lucli_artifacts
+}
+
+setup() {
+    setup_lucli_home
+}
+
+teardown() {
+    cleanup_lucli_home
+}
+
+@test "issue #7: run command executes .cfs script with shebang" {
+    local script_path
+    script_path="$(mktemp "${BATS_TEST_TMPDIR}/shebang-script.XXXXXX.cfs")"
+    cat > "${script_path}" << 'EOF'
+#!/usr/bin/env lucli
+writeOutput("shebang-script-ok");
+EOF
+
+    run_lucli run "${script_path}"
+    assert_success
+    assert_output_contains "shebang-script-ok"
+}
+
+@test "issue #59: aliased module subcommand help is forwarded to module showHelp" {
+    local module_name module_dir
+    module_name="help_route_module_${BATS_TEST_NUMBER}"
+    module_dir="${LUCLI_HOME}/modules/${module_name}"
+
+    run_lucli modules init "${module_name}" --no-git
+    assert_success
+
+    cat > "${module_dir}/Module.cfc" << 'EOF'
+component {
+    function main() {
+        writeOutput("main");
+    }
+
+    function showHelp(string subcommand = "") {
+        if (len(trim(arguments.subcommand))) {
+            writeOutput("SUBCOMMAND_HELP:" & arguments.subcommand);
+        } else {
+            writeOutput("GLOBAL_HELP");
+        }
+    }
+}
+EOF
+
+    run java -Dlucli.binary.name="${module_name}" -jar "${LUCLI_JAR}" migrate --help
+    assert_help_exit_code
+    assert_output_contains "SUBCOMMAND_HELP:migrate"
+}
+
+@test "issue #44: build.sh install target resolves active lucli path first" {
+    run grep -E '^INSTALL_TARGET=\$\(which lucli 2>/dev/null \|\| echo "\$HOME/\.local/bin/lucli"\)$' "${LUCLI_ROOT_DIR}/build.sh"
+    assert_success
+}
+
+@test "issue #44: build.sh install copies binary to resolved INSTALL_TARGET" {
+    run grep -E '^    cp target/lucli "\$INSTALL_TARGET"$' "${LUCLI_ROOT_DIR}/build.sh"
+    assert_success
+}
+
+@test "issue #71: pom configures JReleaser plugin to use jreleaser.yml" {
+    run grep -F '<configFile>${project.basedir}/jreleaser.yml</configFile>' "${LUCLI_ROOT_DIR}/pom.xml"
+    assert_success
+}
+
+@test "issue #71: release workflow invokes jreleaser with explicit config file" {
+    run grep -F 'mvn -DskipTests=true -Djreleaser.config.file=jreleaser.yml jreleaser:full-release' "${LUCLI_ROOT_DIR}/.github/workflows/release.yml"
+    assert_success
+}


### PR DESCRIPTION
## Summary
- add focused BATS regressions for confirmed issues #7, #44, #59, and #71 in `tests/bats/14_confirmed_issue_regressions.bats`
- add a site changelog page at `content/changelog.md`
- add docs/nav links to the changelog in `content/docs/index.md` and `content/layouts/partials/nav.cfm`

## Validation
- `mvn test` (725 run, 0 failures, 0 errors)
- `./tests/test-bats.sh` (full suite, includes the new regression file)

## Context
- Conversation: https://app.warp.dev/conversation/f652f7a3-d168-48d0-92b0-d858fdfce737
