### PR TITLE
Fix deps install lifecycle hook gap for direct command usage

### DIFF
--- a/LEARNINGS.md
+++ b/LEARNINGS.md
@@ -176,3 +176,7 @@ Append new entries at the bottom under the appropriate date/session.
 ## 2026-07-16
 
 - Server lifecycle marker updates should always go through centralized helpers (`writeConfigFileMarker`, `writeEnvironmentMarker`) so default-environment launches reliably clear stale `.environment` values and lifecycle hook loaders stay aligned with persisted startup context.
+
+## 2026-07-17
+
+- For `deps install` lifecycle behavior, hook execution should be wired at `InstallCommand.call()` (root command scope), not inside recursive project install helpers; this ensures `events.before/after.depsInstall` run exactly once per direct command invocation and avoids accidental re-execution during nested dependency installs.

--- a/content/docs/060_server-lifecycle/050_lifecycle-hooks.md
+++ b/content/docs/060_server-lifecycle/050_lifecycle-hooks.md
@@ -59,8 +59,8 @@ The events that you can hook into are:
 | `events.after.serverStop` | After LuCLI successfully stops a running server. |
 | `events.before.serverRestart` | Right before restart begins (before the stop/start sequence). |
 | `events.after.serverRestart` | After restart finishes (after stop + start complete). |
-| `events.before.depsInstall` | Before startup auto-installs dependencies (only when `dependencySettings.autoInstallOnServerStart` is enabled). |
-| `events.after.depsInstall` | After startup auto-installs dependencies (only when `dependencySettings.autoInstallOnServerStart` is enabled). |
+| `events.before.depsInstall` | Before `lucli deps install` runs, and before startup auto-installs dependencies when `dependencySettings.autoInstallOnServerStart` is enabled. |
+| `events.after.depsInstall` | After `lucli deps install` runs, and after startup auto-installs dependencies when `dependencySettings.autoInstallOnServerStart` is enabled. |
 | `events.on.serverStartFailure` | If startup fails and throws an error during server start/run. |
 
 `server start` and `server run` both use the same `serverStart` hook keys.
@@ -93,7 +93,7 @@ If your script file is directly executable in your shell, you can also run it di
 
 ### `depsInstall`
 
-`events.before.depsInstall` and `events.after.depsInstall` run only when dependency auto-install at startup is enabled (`dependencySettings.autoInstallOnServerStart`).
+`events.before.depsInstall` and `events.after.depsInstall` run for direct `lucli deps install`, and also during startup auto-install when `dependencySettings.autoInstallOnServerStart` is enabled.
 
 ## Environment-specific hooks
 

--- a/src/main/java/org/lucee/lucli/cli/commands/deps/InstallCommand.java
+++ b/src/main/java/org/lucee/lucli/cli/commands/deps/InstallCommand.java
@@ -23,6 +23,7 @@ import org.lucee.lucli.deps.ForgeBoxDependencyInstaller;
 import org.lucee.lucli.deps.GitDependencyInstaller;
 import org.lucee.lucli.deps.LockedDependency;
 import org.lucee.lucli.server.LuceeServerManager;
+import org.lucee.lucli.server.LuceeServerConfig;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
@@ -63,15 +64,48 @@ public class InstallCommand implements Callable<Integer> {
     
     @Override
     public Integer call() throws Exception {
+        Path rootProjectDir = Paths.get(".");
+        LuceeServerManager lifecycleServerManager = null;
+        LuceeServerConfig.ServerConfig lifecycleConfig = null;
+        boolean beforeHooksRan = false;
+        int exitCode = 1;
         try {
+            if (!dryRun) {
+                lifecycleConfig = loadDepsLifecycleConfig(rootProjectDir, environment);
+                lifecycleServerManager = new LuceeServerManager();
+                lifecycleServerManager.runDepsInstallLifecycleHooks(lifecycleConfig, rootProjectDir, true);
+                beforeHooksRan = true;
+            }
             // Delegate to project-root aware helper so this can be reused for nested projects later.
             Set<Path> visited = new HashSet<>();
-            return installDependenciesForProject(Paths.get("."), environment, production, force, dryRun, includeNestedDeps, 0, visited);
+            exitCode = installDependenciesForProject(rootProjectDir, environment, production, force, dryRun, includeNestedDeps, 0, visited);
         } catch (Exception e) {
             StringOutput.Quick.error("❌ Error: " + e.getMessage());
             e.printStackTrace();
-            return 1;
+            exitCode = 1;
         }
+
+        if (beforeHooksRan && lifecycleServerManager != null) {
+            try {
+                lifecycleServerManager.runDepsInstallLifecycleHooks(lifecycleConfig, rootProjectDir, false);
+            } catch (Exception hookError) {
+                StringOutput.Quick.error("❌ Error: Failed to run events.after.depsInstall hooks: " + hookError.getMessage());
+                if (LuCLI.verbose || LuCLI.debug) {
+                    hookError.printStackTrace();
+                }
+                exitCode = 1;
+            }
+        }
+        return exitCode;
+    }
+
+    private LuceeServerConfig.ServerConfig loadDepsLifecycleConfig(Path projectDir, String environment) throws Exception {
+        LuceeServerConfig.ServerConfig config = LuceeServerConfig.loadConfig(projectDir);
+        if (environment != null && !environment.trim().isEmpty()) {
+            config = LuceeServerConfig.applyEnvironment(config, environment.trim(), projectDir, "lucee.json");
+        }
+        LuceeServerConfig.resolveSecretPlaceholders(config, projectDir);
+        return config;
     }
 
     /**

--- a/src/main/java/org/lucee/lucli/cli/commands/deps/InstallCommand.java
+++ b/src/main/java/org/lucee/lucli/cli/commands/deps/InstallCommand.java
@@ -100,6 +100,9 @@ public class InstallCommand implements Callable<Integer> {
     }
 
     private LuceeServerConfig.ServerConfig loadDepsLifecycleConfig(Path projectDir, String environment) throws Exception {
+if (!Files.exists(projectDir.resolve("lucee.json"))) {
+            throw new java.io.IOException("lucee.json not found in " + projectDir);
+        }
         LuceeServerConfig.ServerConfig config = LuceeServerConfig.loadConfig(projectDir);
         if (environment != null && !environment.trim().isEmpty()) {
             config = LuceeServerConfig.applyEnvironment(config, environment.trim(), projectDir, "lucee.json");

--- a/tests/bats/05_deps_dry_run.bats
+++ b/tests/bats/05_deps_dry_run.bats
@@ -94,6 +94,32 @@ EOF
     printf '%s\n' "${root_project}"
 }
 
+create_deps_hooks_project() {
+    local project_dir
+    project_dir="$(mktemp -d "${BATS_TEST_TMPDIR}/deps-hooks-project.XXXXXX")"
+
+    cat > "${project_dir}/lucee.json" << 'EOF'
+{
+  "name": "deps-hooks-project",
+  "dependencies": {},
+  "events": {
+    "before": {
+      "depsInstall": [
+        "touch .before-deps-install-hook"
+      ]
+    },
+    "after": {
+      "depsInstall": [
+        "touch .after-deps-install-hook"
+      ]
+    }
+  }
+}
+EOF
+
+    printf '%s\n' "${project_dir}"
+}
+
 @test "deps dry-run shows root install plan without nested blocks" {
     local root_project
     root_project="$(create_nested_deps_project)"
@@ -130,4 +156,25 @@ EOF
     run bash -c 'cd "$1" && java -jar "$2" deps install --dry-run --include-nested-deps' _ "${root_project}" "${LUCLI_JAR}"
     assert_success
     assert_output_contains "maximum nested dependency depth"
+}
+
+@test "deps install runs before/after depsInstall lifecycle hooks" {
+    local project_dir
+    project_dir="$(create_deps_hooks_project)"
+
+    run bash -c 'cd "$1" && java -jar "$2" deps install' _ "${project_dir}" "${LUCLI_JAR}"
+    assert_success
+    assert_output_contains "No git or extension dependencies to install"
+    [[ -f "${project_dir}/.before-deps-install-hook" ]]
+    [[ -f "${project_dir}/.after-deps-install-hook" ]]
+}
+
+@test "deps install --dry-run does not run depsInstall lifecycle hooks" {
+    local project_dir
+    project_dir="$(create_deps_hooks_project)"
+
+    run bash -c 'cd "$1" && java -jar "$2" deps install --dry-run' _ "${project_dir}" "${LUCLI_JAR}"
+    assert_success
+    [[ ! -f "${project_dir}/.before-deps-install-hook" ]]
+    [[ ! -f "${project_dir}/.after-deps-install-hook" ]]
 }


### PR DESCRIPTION
## Summary
- run `events.before.depsInstall` and `events.after.depsInstall` for direct `lucli deps install` (non-dry-run)
- keep `--dry-run` hook-free to avoid side effects
- load lifecycle config through `LuceeServerConfig` (including `--env` and secret resolution) before hook execution

## Testing
- mvn test
- ./tests/test-bats.sh

## Related
- Closes #111

## Artifacts
- Warp conversation: https://app.warp.dev/conversation/d7471bf9-63d5-4dff-bbe9-e4737d22870f